### PR TITLE
Update  DoctrinePHPCRBundle's config file

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -17,9 +17,9 @@ twig:
     strict_variables: %kernel.debug%
 
 doctrine_phpcr:
-    backend:
-        url: http://localhost:8080/server/
+    session:
+        backend:
+            url: http://localhost:8080/server/
         workspace: default
-        user: admin
-        pass: admin
-
+        username: admin
+        password: admin


### PR DESCRIPTION
DoctrinePHPCRBundle's config file requirements has changed. Actually, bin/vendor.sh ends with an error
 [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]   Unrecognized options "backend" under "doctrine_phpcr"
