### PR TITLE
Fixtures update to preserve menu formatting with recent knpmenu changes

### DIFF
--- a/src/Sandbox/MainBundle/Resources/data/fixtures/030_LoadMenuData.php
+++ b/src/Sandbox/MainBundle/Resources/data/fixtures/030_LoadMenuData.php
@@ -40,7 +40,7 @@ class LoadMenuData implements FixtureInterface, OrderedFixtureInterface, Contain
 
         // REMEMBER: all menu items must be named -item !
         $menuitem = $this->createMenuItem("$base_path/main", 'Main menu', array('en' => 'Home', 'de' => 'Start', 'fr' => 'Acceuil'), $this->dm->find(null, "$content_path/home"));
-        $menuitem->setAttributes(array("class" => "menu_main"));
+        $menuitem->setChildrenAttributes(array("class" => "menu_main"));
 
         $this->createMenuItem("$base_path/main/admin-item", 'Adminitem', 'Admin', null, null, 'sonata_admin_dashboard');
 


### PR DESCRIPTION
Small menu fixture change to allow for using most recent KnpMenu. In support of 
   symfony-cmf/symfony-cmf#139 
   symfony-cmf/symfony-cmf#140

If these updates are considered too minor to be worth pulling in for now then I understand - I've just submitted them as Im using them myself.

Before merging, along with the deps.lock update to most recent knp menu, it would also require:
    - deps.lock for the symfony-cmf updating once 139 and 140 linked above are merged
    - deps.lock updating to a more recent KnpMenuBundle to account for the MenuProviderInterface updates 
