### PR TITLE
use rootNode for phpcr tree

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -115,6 +115,8 @@ sonata_block:
         sonata.admin.block.admin_list:
             contexts:   [admin]
         sonata_admin_doctrine_phpcr.tree_block:
+            settings:
+                id: '/cms'
             contexts:   [admin]
 
 sonata_admin:

--- a/src/Sandbox/AdminBundle/Admin/RouteAdmin.php
+++ b/src/Sandbox/AdminBundle/Admin/RouteAdmin.php
@@ -24,7 +24,7 @@ class RouteAdmin extends Admin
                 //TODO ->add('parent', 'text')
                 //TODO ->add('name', 'text')
                 ->add('variablePattern', 'text', array('required' => false))
-                ->add('routeContent', 'doctrine_phpcr_type_tree_model', array('class' => 'Sandbox\MainBundle\Document\EditableStaticContent', 'required' => false))
+                ->add('routeContent', 'doctrine_phpcr_type_tree_model', array('class' => 'Sandbox\MainBundle\Document\EditableStaticContent', 'required' => false, 'rootNode' => '/cms/content'))
                 // TODO edit key-value fields for defaults and options
             ->end();
     }


### PR DESCRIPTION
use the rootNode option of the phpcrbrowsertree for the navigation tree in the admin and for selecting content in the route admin
