### PR TITLE
For NFS to work Vagrant complained that hostonly should be enabled.

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant::Config.run do |config|
   # Boot with a GUI so you can see the screen. (Default is headless)
   # config.vm.boot_mode = :gui
 
-  config.vm.network "33.33.33.10"
+  config.vm.network :hostonly, "33.33.33.10"
 
   config.vm.share_folder "app", "/app", "..", :nfs => true
 


### PR DESCRIPTION
Still haven't been able to run cmf-sandbox tough.
Almost all bundles installed via composer require php >= 5.3.3 while Vagrant supplies 5.3.2
