### PR TITLE
Vagrant Customise Failure

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant::Config.run do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "precise32"
   config.vm.host_name = "cmfsandbox"
-  config.vm.customize ["modifyvm", :id, "--memory", 768]
+  config.vm.customize ["modifyvm", :id, "--memory", "768"]
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.


### PR DESCRIPTION
Vagrant version: 0.9.3
Ruby version: ruby 1.8.7 (2011-12-28 patchlevel 357)
[universal-darwin11.0]

Executing `vagrant up` results in a TypeError. Changing the Integer, passed
into config.vm.customize, into a String fixes this.
