### PR TITLE
adjust fixture loading to not do weird things anymore

### DIFF
--- a/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadStaticPageData.php
+++ b/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadStaticPageData.php
@@ -94,7 +94,10 @@ class LoadStaticPageData extends ContainerAware implements FixtureInterface, Ord
         }
 
         if ($className == 'Symfony\Cmf\Bundle\BlockBundle\Document\ReferenceBlock') {
-            $referencedBlock = $this->container->get('symfony_cmf.block.service')->findByName($block['referencedBlock']);
+            $referencedBlock = $manager->find(null, $block['referencedBlock']);
+            if (null == $referencedBlock) {
+                throw new \Exception('did not find '.$block['referencedBlock']);
+            }
             $document->setReferencedBlock($referencedBlock);
         } else if ($className == 'Symfony\Cmf\Bundle\BlockBundle\Document\ActionBlock') {
             $document->setActionName($block['actionName']);


### PR DESCRIPTION
this will clean the sandbox. we should do a full composer update too, but currently we miss https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/71 - until that is merged, we should not merge this
