### PR TITLE
set route_basepath in config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -84,6 +84,7 @@ doctrine_phpcr:
                 - de
 
 symfony_cmf_routing_extra:
+    route_basepath: /cms/routes
     chain:
         routers_by_id:
             symfony_cmf_routing_extra.dynamic_router: 20


### PR DESCRIPTION
This will prevent appearing of the "Content" and "Menu" nodes, which are superfluous in the parent property of the Route for example.
