### PR TITLE
added RedirectRouteAdmin link to the dashboard

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -157,6 +157,7 @@ sonata_admin:
                 label: page routes
                 items:
                     - symfony_cmf_routing_extra.route_admin
+                    - symfony_cmf_routing_extra.redirect_route_admin
             menu:
                 label: menu structure
                 items:


### PR DESCRIPTION
As soon as this one here:
https://github.com/symfony-cmf/RoutingExtraBundle/pull/62
is merged. We will need to enable it in the Sandbox.
