### PR TITLE
[WIP] sonata media example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 composer.phar
 web/bundles/
+web/uploads/
+web/media/
 web/js/
 web/css/
 app/cache/*

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -54,6 +54,12 @@ class AppKernel extends Kernel
             new Sonata\AdminBundle\SonataAdminBundle(),
             new Sonata\DoctrinePHPCRAdminBundle\SonataDoctrinePHPCRAdminBundle(),
             new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
+            new Sandbox\MediaBundle\SandboxMediaBundle(),
+            new Sandbox\BannerBundle\SandboxBannerBundle(),
+
+            // Media support
+            new Sonata\MediaBundle\SonataMediaBundle(),
+            new Liip\ImagineBundle\LiipImagineBundle(),
 
             // jackalope doctrine caching
             // new Liip\DoctrineCacheBundle\LiipDoctrineCacheBundle(),

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -35,6 +35,7 @@ class AppKernel extends Kernel
             new Symfony\Cmf\Bundle\BlogBundle\CmfBlogBundle(),
             new Liip\SearchBundle\LiipSearchBundle(),
             new Symfony\Cmf\Bundle\SearchBundle\CmfSearchBundle(),
+            new Symfony\Cmf\Bundle\MediaBundle\CmfMediaBundle(),
 
             // language switcher
             new Lunetics\LocaleBundle\LuneticsLocaleBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -21,6 +21,9 @@ framework:
 twig:
     debug:            %kernel.debug%
     strict_variables: %kernel.debug%
+    form:
+        resources:
+            - 'CmfMediaBundle:Form:fields.html.twig'
 
 # Assetic Configuration
 assetic:
@@ -136,6 +139,11 @@ cmf_menu:
 cmf_blog:
     blog_basepath: /cms/content
 
+cmf_block:
+    imagine: true
+
+cmf_media:
+    imagine_filter: image_upload_thumbnail
 
 sonata_block:
     default_contexts: [cms]
@@ -174,6 +182,8 @@ sonata_admin:
                     - cmf_block.container_admin
                     - cmf_block.reference_admin
                     - cmf_block.action_admin
+                    - cmf_block.imagine.multilang_slideshow_admin
+                    - cmf_block.imagine.multilang_imagine_admin
                     - sandbox_banner.admin.image_block                    
             routing:
                 label: page routes
@@ -219,12 +229,26 @@ sonata_doctrine_phpcr_admin:
             valid_children: []
         Symfony\Cmf\Bundle\BlockBundle\Document\SimpleBlock:
             valid_children: []
+        Symfony\Cmf\Bundle\BlockBundle\Document\SlideshowBlock:
+            valid_children:
+                - Symfony\Cmf\Bundle\BlockBundle\Document\ImagineBlock
+        Symfony\Cmf\Bundle\BlockBundle\Document\MultilangSlideshowBlock:
+            valid_children:
+                - Symfony\Cmf\Bundle\BlockBundle\Document\MultilangImagineBlock
+        Symfony\Cmf\Bundle\BlockBundle\Document\ImagineBlock:
+            valid_children: []
+        Symfony\Cmf\Bundle\BlockBundle\Document\MultilangImagineBlock:
+            valid_children: []
         Symfony\Cmf\Bundle\BlockBundle\Document\ContainerBlock:
             valid_children:
                 - Symfony\Cmf\Bundle\BlockBundle\Document\SimpleBlock
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ContainerBlock
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ReferenceBlock
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ActionBlock
+                - Symfony\Cmf\Bundle\BlockBundle\Document\SlideshowBlock
+                - Symfony\Cmf\Bundle\BlockBundle\Document\MultilangSlideshowBlock
+                - Symfony\Cmf\Bundle\BlockBundle\Document\ImagineBlock
+                - Symfony\Cmf\Bundle\BlockBundle\Document\MultilangImagineBlock
                 - Sandbox\BannerBundle\Document\ImageBlock
         Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page: ~
         Symfony\Cmf\Bundle\RoutingBundle\Document\Route:
@@ -401,3 +425,15 @@ liip_imagine:
             controller_action: 'SonataMediaBundle:Media:liipImagineFilter'
             filters:
                 thumbnail: { size: [500, 200], mode: outbound }
+
+        # define the filter to be used with the image preview
+        image_upload_thumbnail:
+            data_loader: cmf_media_doctrine_phpcr
+            filters:
+                thumbnail: { size: [100, 100], mode: outbound }
+
+        cmf_block:
+            data_loader: cmf_media_doctrine_phpcr
+            quality: 85
+            filters:
+                thumbnail: { size: [50, 50], mode: outbound }

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -71,6 +71,9 @@ doctrine_phpcr:
     odm:
         auto_mapping: true
         auto_generate_proxy_classes: %kernel.debug%
+        mappings:
+            SonataMediaBundle:
+                prefix: Sonata\MediaBundle\PHPCR
         locales:
             en:
                 - de
@@ -171,6 +174,7 @@ sonata_admin:
                     - cmf_block.container_admin
                     - cmf_block.reference_admin
                     - cmf_block.action_admin
+                    - sandbox_banner.admin.image_block                    
             routing:
                 label: page routes
                 items:
@@ -186,6 +190,11 @@ sonata_admin:
                 items:
                     - cmf_blog.admin
                     - cmf_post.admin
+            media:
+                label: media library
+                items:
+                    - sonata.media.admin.media
+                    - sonata.media.admin.gallery                    
             simplecms:
                 label: simple cms (content/routing/menu as one)
                 items:
@@ -203,6 +212,7 @@ sonata_doctrine_phpcr_admin:
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ContainerBlock
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ReferenceBlock
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ActionBlock
+                - Sandbox\BannerBundle\Document\ImageBlock
         Symfony\Cmf\Bundle\BlockBundle\Document\ReferenceBlock:
             valid_children: []
         Symfony\Cmf\Bundle\BlockBundle\Document\ActionBlock:
@@ -215,6 +225,7 @@ sonata_doctrine_phpcr_admin:
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ContainerBlock
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ReferenceBlock
                 - Symfony\Cmf\Bundle\BlockBundle\Document\ActionBlock
+                - Sandbox\BannerBundle\Document\ImageBlock
         Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page: ~
         Symfony\Cmf\Bundle\RoutingBundle\Document\Route:
             valid_children:
@@ -236,6 +247,32 @@ sonata_doctrine_phpcr_admin:
         Symfony\Cmf\Bundle\BlogBundle\Document\Post:
             valid_children: []
 
+        # media
+        Sandbox\MediaBundle\Document\MediaRoot:
+            image: /bundles/sonataadmin/famfamfam/folder_image.png
+            valid_children:
+                - Sandbox\MediaBundle\Document\Media
+        Sandbox\MediaBundle\Document\GalleryRoot:
+            image: /bundles/sonataadmin/famfamfam/images.png
+            valid_children:
+                - Sandbox\MediaBundle\Document\Gallery
+        Sandbox\MediaBundle\Document\Media:
+            image: /bundles/sonataadmin/famfamfam/image.png
+            valid_children: []
+        Sandbox\MediaBundle\Document\Gallery:
+            valid_children: []
+        Sandbox\MediaBundle\Document\GalleryHasMedia:
+            valid_children: []
+
+        # banner
+        Sandbox\BannerBundle\Document\ImageBlock:
+            image: /bundles/sonataadmin/famfamfam/images.png
+            valid_children:
+                - Sandbox\BannerBundle\Document\BannerImage
+        Sandbox\BannerBundle\Document\BannerImage:
+            image: /bundles/sonataadmin/famfamfam/picture.png
+            valid_children: []
+
 fos_js_routing:
     routes_to_expose:
         - admin_bundle_menu_menunode_*
@@ -253,6 +290,13 @@ fos_js_routing:
         - cmf_tree_browser.phpcr_move
         - sonata.admin.doctrine_phpcr.phpcrodm_children
         - sonata.admin.doctrine_phpcr.phpcrodm_move
+
+        # media
+        - admin_sandbox_media_media_*
+        - admin_sandbox_media_gallery_*
+
+        # banner
+        - admin_sandbox_banner_imageblock_*
 
 sensio_framework_extra:
     view:    { annotations: false }
@@ -285,3 +329,75 @@ lunetics_locale:
 #            type: file_system
 #        nodes:
 #            type: file_system
+
+#jms_di_extra:
+#    locations:
+#        bundles: [ SandboxMediaBundle ]
+#    doctrine_integration: true # currently on supported for Doctrine ORM
+
+# SonataMediaBundle
+# more information can be found here http://sonata-project.org/bundles/media
+sonata_media:
+    class:
+        media:              Sandbox\MediaBundle\Document\Media
+        gallery:            Sandbox\MediaBundle\Document\Gallery
+        gallery_has_media:  Sandbox\MediaBundle\Document\GalleryHasMedia
+    default_context: default
+    db_driver: doctrine_phpcr # or doctrine_orm, doctrine_mongodb
+    contexts:
+        default: # the default context is mandatory
+            providers:
+                - sonata.media.provider.image
+#                - sonata.media.provider.dailymotion
+#                - sonata.media.provider.youtube
+#                - sonata.media.provider.file
+#                - sonata.media.provider.vimeo
+
+            formats:
+                # if using liip_imagine these formats are only used in the view of the admin
+                # define a format as filter_set in liip_imagine: {context}_{format}
+                small: { width: 100 , quality: 70 }
+                big:   { width: 500 , quality: 70 }
+
+    cdn:
+        # define the base url for the uploaded media
+        server:
+            path: /uploads/media
+#
+    filesystem:
+        # define where the uploaded file will be stored
+        local:
+            directory: %kernel.root_dir%/../web/uploads/media
+            create: true
+
+#    providers:
+#        image:
+#            resizer: sonata.media.resizer.square
+
+#    pixlr:
+#        enabled: true
+#        referrer: Demo - Sonata Project
+
+# The LiipImagineBundle can be used if you want to convert on demand an image
+# to a specific format. (ie a controller render the file)
+# more information can be found here : https://github.com/liip/LiipImagineBundle
+liip_imagine:
+    filter_sets:
+        # sonata media admin list thumbs
+        admin:
+            quality: 70
+            controller_action: 'SonataMediaBundle:Media:liipImagineFilter'
+            filters:
+                thumbnail: { size: [75, 60], mode: outbound }
+
+        # sonata media admin context default filters
+        default_small:
+            quality: 70
+            controller_action: 'SonataMediaBundle:Media:liipImagineFilter'
+            filters:
+                thumbnail: { size: [100, 75], mode: outbound }
+
+        default_big:
+            controller_action: 'SonataMediaBundle:Media:liipImagineFilter'
+            filters:
+                thumbnail: { size: [500, 200], mode: outbound }

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -40,6 +40,30 @@ sonata_admin:
     resource: .
     type: sonata_admin
     prefix: /{_locale}/admin
+    requirements:
+        id:  .+
+
+sonata_media_gallery:
+    resource: '@SonataMediaBundle/Resources/config/routing/gallery.xml'
+    prefix: /media/gallery
+    requirements:
+        id:  .+
+
+sonata_media_media:
+    resource: '@SonataMediaBundle/Resources/config/routing/media.xml'
+    prefix: /media
+    requirements:
+        id:  .+
+
+#sonata_media_pixlr:
+#    resource: '@SonataMediaBundle/Resources/config/routing/pixlr.xml'
+#    prefix: /admin/media
+#    requirements:
+#        id:  .+
+
+_imagine:
+    resource: .
+    type:     imagine
 
 fos_js_routing:
     resource: @FOSJsRoutingBundle/Resources/config/routing/routing.xml

--- a/app/tests/AdminDashboardTest.php
+++ b/app/tests/AdminDashboardTest.php
@@ -36,6 +36,6 @@ class AdminDashboardTest extends WebTestCase
         $this->assertContains('Sonata Admin', $response->getContent());
 
         $this->assertCount(2, $crawler->filter('.container-fluid'));
-        $this->assertCount(12, $crawler->filter('.sonata-ba-list-label'));
+        $this->assertCount(15, $crawler->filter('.sonata-ba-list-label'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,9 @@
         "symfony-cmf/routing-auto-bundle": "1.0.0-alpha2",
         "symfony-cmf/blog-bundle": "1.0.0-alpha2",
         "sonata-project/cache-bundle": "2.1.*",
-        "eko/feedbundle": "1.0.*"
+        "eko/feedbundle": "1.0.*",
+        "sonata-project/media-bundle": "2.2.*",
+        "liip/imagine-bundle": "1.0.*"
     },
     "suggest": {
         "jackalope/jackalope-doctrine-dbal": "1.0.0-alpha1",

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,32 @@
         "sonata-project/cache-bundle": "2.1.*",
         "eko/feedbundle": "1.0.*",
         "sonata-project/media-bundle": "2.2.*",
-        "liip/imagine-bundle": "1.0.*"
+        "liip/imagine-bundle": "1.0.*",
+        "symfony-cmf/media-bundle": "dev-master"
     },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "symfony-cmf/media-bundle",
+                "autoload":{
+                    "psr-0":{
+                        "Symfony\\Cmf\\Bundle\\MediaBundle": ""
+                    }
+                },
+                "version": "dev-master",
+                "target-dir": "Symfony/Cmf/Bundle/MediaBundle",
+                "source": {
+                    "reference": "define-interfaces",
+                    "url": "https://github.com/symfony-cmf/MediaBundle.git",
+                    "type": "git"
+                }
+            },
+            "require": {
+                "php": ">=5.3.2"
+            }
+        }
+    ],
     "suggest": {
         "jackalope/jackalope-doctrine-dbal": "1.0.0-alpha1",
         "midgard/phpcr": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "646371fbb6d94567135c05eb23de6de0",
+    "hash": "c99d843359b99faae8d02e775d7745ba",
     "packages": [
         {
             "name": "aferrandini/urlizer",
@@ -262,12 +262,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "d658ec7a03f6475eff0dd1eb940bdedd862e4b96"
+                "reference": "2169b0ce1d253d448c60b7d40bbe4e4b5afe22fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/d658ec7a03f6475eff0dd1eb940bdedd862e4b96",
-                "reference": "d658ec7a03f6475eff0dd1eb940bdedd862e4b96",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/2169b0ce1d253d448c60b7d40bbe4e4b5afe22fe",
+                "reference": "2169b0ce1d253d448c60b7d40bbe4e4b5afe22fe",
                 "shasum": ""
             },
             "require": {
@@ -328,7 +328,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2013-06-10 18:20:01"
+            "time": "2013-05-27 19:11:46"
         },
         {
             "name": "doctrine/data-fixtures",
@@ -391,12 +391,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "226dba897d1d3617ed04b968582f775da4aa5e1b"
+                "reference": "5a8eedf627339ed682d1a2d8d3a4aaf8ac8af750"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/226dba897d1d3617ed04b968582f775da4aa5e1b",
-                "reference": "226dba897d1d3617ed04b968582f775da4aa5e1b",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/5a8eedf627339ed682d1a2d8d3a4aaf8ac8af750",
+                "reference": "5a8eedf627339ed682d1a2d8d3a4aaf8ac8af750",
                 "shasum": ""
             },
             "require": {
@@ -453,7 +453,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2013-06-09 23:08:46"
+            "time": "2013-06-07 18:55:27"
         },
         {
             "name": "doctrine/doctrine-bundle",
@@ -714,12 +714,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/doctrine2.git",
-                "reference": "4e8b787d072fe48e798a1bd5cd05f08e9a083525"
+                "reference": "462173ad71ae63cd9877e1e642f7968ed1f9971b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/4e8b787d072fe48e798a1bd5cd05f08e9a083525",
-                "reference": "4e8b787d072fe48e798a1bd5cd05f08e9a083525",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/462173ad71ae63cd9877e1e642f7968ed1f9971b",
+                "reference": "462173ad71ae63cd9877e1e642f7968ed1f9971b",
                 "shasum": ""
             },
             "require": {
@@ -780,7 +780,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2013-05-28 07:36:17"
+            "time": "2013-06-07 21:42:59"
         },
         {
             "name": "doctrine/phpcr-bundle",
@@ -843,7 +843,7 @@
                 "persistence",
                 "phpcr"
             ],
-            "time": "2013-05-28 20:12:46"
+            "time": "2013-05-30 21:10:01"
         },
         {
             "name": "doctrine/phpcr-odm",
@@ -2010,12 +2010,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/kriswallsmith/assetic.git",
-                "reference": "dfcbf3d19bafa0f00549bc10dba0ca19c8b3185b"
+                "reference": "0e18168c45df6500617ad8739f122fdf917a9293"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/dfcbf3d19bafa0f00549bc10dba0ca19c8b3185b",
-                "reference": "dfcbf3d19bafa0f00549bc10dba0ca19c8b3185b",
+                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/0e18168c45df6500617ad8739f122fdf917a9293",
+                "reference": "0e18168c45df6500617ad8739f122fdf917a9293",
                 "shasum": ""
             },
             "require": {
@@ -2073,7 +2073,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2013-06-06 22:11:45"
+            "time": "2013-06-13 16:56:43"
         },
         {
             "name": "kriswallsmith/buzz",
@@ -2245,17 +2245,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipSearchBundle.git",
-                "reference": "132f6608ac70b2a91d7f473d8cfc8417ac150a7e"
+                "reference": "0c0b6fc9fcd9979968dcaaf8c11ecf95fb6a4004"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipSearchBundle/zipball/132f6608ac70b2a91d7f473d8cfc8417ac150a7e",
-                "reference": "132f6608ac70b2a91d7f473d8cfc8417ac150a7e",
+                "url": "https://api.github.com/repos/liip/LiipSearchBundle/zipball/0c0b6fc9fcd9979968dcaaf8c11ecf95fb6a4004",
+                "reference": "0c0b6fc9fcd9979968dcaaf8c11ecf95fb6a4004",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0",
-                "symfony/framework-bundle": ">=2.1,<3.0"
+                "symfony/framework-bundle": ">2.0,<2.3-dev"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -2286,7 +2286,7 @@
             "keywords": [
                 "Symfony2"
             ],
-            "time": "2013-06-11 10:39:34"
+            "time": "2013-04-22 12:37:01"
         },
         {
             "name": "lunetics/locale-bundle",
@@ -2401,12 +2401,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "a43f926ffee4de41f14016dbee2aac1ed2cb411a"
+                "reference": "a3864e0b9f0d35ee50e1e3f0a1f73cef56d50e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a43f926ffee4de41f14016dbee2aac1ed2cb411a",
-                "reference": "a43f926ffee4de41f14016dbee2aac1ed2cb411a",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/a3864e0b9f0d35ee50e1e3f0a1f73cef56d50e87",
+                "reference": "a3864e0b9f0d35ee50e1e3f0a1f73cef56d50e87",
                 "shasum": ""
             },
             "require": {
@@ -2455,7 +2455,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2013-06-07 08:26:36"
+            "time": "2013-05-28 12:09:06"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -2567,12 +2567,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpcr/phpcr-utils.git",
-                "reference": "9360d81ea8c40891801bebe0aac4792f3a6dbb4b"
+                "reference": "7d5c46b05a95f6928118508857bc90efb14be6e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpcr/phpcr-utils/zipball/9360d81ea8c40891801bebe0aac4792f3a6dbb4b",
-                "reference": "9360d81ea8c40891801bebe0aac4792f3a6dbb4b",
+                "url": "https://api.github.com/repos/phpcr/phpcr-utils/zipball/7d5c46b05a95f6928118508857bc90efb14be6e3",
+                "reference": "7d5c46b05a95f6928118508857bc90efb14be6e3",
                 "shasum": ""
             },
             "require": {
@@ -2621,7 +2621,7 @@
                 "contentrepository",
                 "phpcr"
             ],
-            "time": "2013-06-10 18:32:22"
+            "time": "2013-05-22 14:16:25"
         },
         {
             "name": "phpoption/phpoption",
@@ -2762,13 +2762,13 @@
             "target-dir": "Sensio/Bundle/FrameworkExtraBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "v2.2.2"
+                "url": "https://github.com/sensio/SensioFrameworkExtraBundle.git",
+                "reference": "09041c1f95f4ad9c9a23eb9d23d9d110cde94a44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/v2.2.2",
-                "reference": "v2.2.2",
+                "url": "https://api.github.com/repos/sensio/SensioFrameworkExtraBundle/zipball/09041c1f95f4ad9c9a23eb9d23d9d110cde94a44",
+                "reference": "09041c1f95f4ad9c9a23eb9d23d9d110cde94a44",
                 "shasum": ""
             },
             "require": {
@@ -2801,7 +2801,7 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2013-06-02 13:06:28"
+            "time": "2013-04-11 06:46:09"
         },
         {
             "name": "sensio/generator-bundle",
@@ -2809,13 +2809,13 @@
             "target-dir": "Sensio/Bundle/GeneratorBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "v2.2.2"
+                "url": "https://github.com/sensio/SensioGeneratorBundle.git",
+                "reference": "781c1a93a705fc823e2b65dd85e322b4eb77fef8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/v2.2.2",
-                "reference": "v2.2.2",
+                "url": "https://api.github.com/repos/sensio/SensioGeneratorBundle/zipball/781c1a93a705fc823e2b65dd85e322b4eb77fef8",
+                "reference": "781c1a93a705fc823e2b65dd85e322b4eb77fef8",
                 "shasum": ""
             },
             "require": {
@@ -2849,7 +2849,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2013-06-02 13:07:01"
+            "time": "2013-05-07 13:40:47"
         },
         {
             "name": "sonata-project/admin-bundle",
@@ -2858,12 +2858,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sonata-project/SonataAdminBundle.git",
-                "reference": "fa0088c2f0a2141f9365266ee26a35c10b6ec8a9"
+                "reference": "849e84143ab14fc7b9c436db455952c92c139c51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sonata-project/SonataAdminBundle/zipball/fa0088c2f0a2141f9365266ee26a35c10b6ec8a9",
-                "reference": "fa0088c2f0a2141f9365266ee26a35c10b6ec8a9",
+                "url": "https://api.github.com/repos/sonata-project/SonataAdminBundle/zipball/849e84143ab14fc7b9c436db455952c92c139c51",
+                "reference": "849e84143ab14fc7b9c436db455952c92c139c51",
                 "shasum": ""
             },
             "require": {
@@ -2924,7 +2924,7 @@
                 "bootstrap",
                 "sonata"
             ],
-            "time": "2013-06-10 22:30:44"
+            "time": "2013-05-23 13:42:50"
         },
         {
             "name": "sonata-project/block-bundle",
@@ -3164,7 +3164,7 @@
                 "bootstrap",
                 "sonata"
             ],
-            "time": "2013-05-25 18:41:26"
+            "time": "2013-05-30 05:53:54"
         },
         {
             "name": "sonata-project/easy-extends-bundle",
@@ -3331,12 +3331,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sonata-project/SonataMediaBundle.git",
-                "reference": "24e9faa9a87824850762397671db7959f680187c"
+                "reference": "a1abcf577c586ae743ebf5abaa798219830b2ff5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sonata-project/SonataMediaBundle/zipball/24e9faa9a87824850762397671db7959f680187c",
-                "reference": "24e9faa9a87824850762397671db7959f680187c",
+                "url": "https://api.github.com/repos/sonata-project/SonataMediaBundle/zipball/a1abcf577c586ae743ebf5abaa798219830b2ff5",
+                "reference": "a1abcf577c586ae743ebf5abaa798219830b2ff5",
                 "shasum": ""
             },
             "require": {
@@ -3398,7 +3398,7 @@
                 "vimeo",
                 "youtube"
             ],
-            "time": "2013-06-01 16:38:00"
+            "time": "2013-06-07 21:06:03"
         },
         {
             "name": "sonata-project/notification-bundle",
@@ -3794,6 +3794,22 @@
             "time": "2013-05-26 11:19:11"
         },
         {
+            "name": "symfony-cmf/media-bundle",
+            "version": "dev-master",
+            "target-dir": "Symfony/Cmf/Bundle/MediaBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony-cmf/MediaBundle.git",
+                "reference": "define-interfaces"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Cmf\\Bundle\\MediaBundle": ""
+                }
+            }
+        },
+        {
             "name": "symfony-cmf/menu-bundle",
             "version": "1.0.0-alpha3",
             "target-dir": "Symfony/Cmf/Bundle/MenuBundle",
@@ -3849,7 +3865,7 @@
                 "Symfony CMF",
                 "menu"
             ],
-            "time": "2013-05-25 18:03:41"
+            "time": "2013-05-29 09:54:20"
         },
         {
             "name": "symfony-cmf/routing",
@@ -3858,22 +3874,22 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony-cmf/Routing.git",
-                "reference": "3b2f6da542f41be853fb1c9a2623b8e0cb9bb674"
+                "reference": "1dabb1f3503bb2539df9cc20444a258be4011c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/Routing/zipball/3b2f6da542f41be853fb1c9a2623b8e0cb9bb674",
-                "reference": "3b2f6da542f41be853fb1c9a2623b8e0cb9bb674",
+                "url": "https://api.github.com/repos/symfony-cmf/Routing/zipball/1dabb1f3503bb2539df9cc20444a258be4011c28",
+                "reference": "1dabb1f3503bb2539df9cc20444a258be4011c28",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=5.3.2",
                 "psr/log": ">=1.0,<2.0",
-                "symfony/http-kernel": ">=2.2,<3.0",
-                "symfony/routing": ">=2.2,<3.0"
+                "symfony/http-kernel": ">=2.2,<2.4-dev",
+                "symfony/routing": ">=2.2,<2.4-dev"
             },
             "suggest": {
-                "symfony/http-foundation": "ChainRouter/DynamicRouter have optional support for Request instances, several enhancers require a Request instances, ~2.2"
+                "symfony/http-foundation": "ChainRouter/DynamicRouter have optional support for Request instances, several enhancers require a Request instances, >=2.2,<2.3-dev"
             },
             "type": "library",
             "extra": {
@@ -3902,7 +3918,7 @@
                 "database",
                 "routing"
             ],
-            "time": "2013-06-03 17:23:01"
+            "time": "2013-05-31 11:26:26"
         },
         {
             "name": "symfony-cmf/routing-auto-bundle",
@@ -4029,7 +4045,7 @@
                 "database",
                 "routing"
             ],
-            "time": "2013-05-28 12:32:54"
+            "time": "2013-05-31 06:17:04"
         },
         {
             "name": "symfony-cmf/search-bundle",
@@ -4261,21 +4277,21 @@
         },
         {
             "name": "symfony/assetic-bundle",
-            "version": "2.1.x-dev",
+            "version": "dev-master",
             "target-dir": "Symfony/Bundle/AsseticBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/AsseticBundle.git",
-                "reference": "49ed2a7aa9942e5564c7211a3ed5ea974f61b687"
+                "reference": "v2.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/AsseticBundle/zipball/49ed2a7aa9942e5564c7211a3ed5ea974f61b687",
-                "reference": "49ed2a7aa9942e5564c7211a3ed5ea974f61b687",
+                "url": "https://api.github.com/repos/symfony/AsseticBundle/zipball/v2.3.0",
+                "reference": "v2.3.0",
                 "shasum": ""
             },
             "require": {
-                "kriswallsmith/assetic": "1.1.x",
+                "kriswallsmith/assetic": ">=1.1,<2.0",
                 "php": ">=5.3.0",
                 "symfony/framework-bundle": ">=2.1,<3.0"
             },
@@ -4320,21 +4336,21 @@
                 "compression",
                 "minification"
             ],
-            "time": "2013-06-07 16:26:30"
+            "time": "2013-05-16 05:32:23"
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "2.2.x-dev",
+            "version": "dev-master",
             "target-dir": "Symfony/Bundle/MonologBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/MonologBundle.git",
-                "reference": "3c4b4c43933f93e6f887df201bdbbb10a1bf5b97"
+                "reference": "03ed73bc11367b3156cc21f22ac37c7f70fcd10a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/3c4b4c43933f93e6f887df201bdbbb10a1bf5b97",
-                "reference": "3c4b4c43933f93e6f887df201bdbbb10a1bf5b97",
+                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/03ed73bc11367b3156cc21f22ac37c7f70fcd10a",
+                "reference": "03ed73bc11367b3156cc21f22ac37c7f70fcd10a",
                 "shasum": ""
             },
             "require": {
@@ -4378,7 +4394,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2013-06-05 09:21:54"
+            "time": "2013-05-27 18:06:55"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -4441,12 +4457,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "d85ce5e5ad31e6546df45520240705f26e1dcefb"
+                "reference": "afee664e8acceff7dad8cd111d8c77abf4035330"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/d85ce5e5ad31e6546df45520240705f26e1dcefb",
-                "reference": "d85ce5e5ad31e6546df45520240705f26e1dcefb",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/afee664e8acceff7dad8cd111d8c77abf4035330",
+                "reference": "afee664e8acceff7dad8cd111d8c77abf4035330",
                 "shasum": ""
             },
             "require": {
@@ -4532,7 +4548,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2013-06-11 07:14:33"
+            "time": "2013-05-27 20:40:05"
         },
         {
             "name": "twig/extensions",
@@ -4540,16 +4556,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/fabpot/Twig-extensions.git",
-                "reference": "4239a9b107c17547da91d76005c996f08e164ae8"
+                "reference": "v1.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fabpot/Twig-extensions/zipball/4239a9b107c17547da91d76005c996f08e164ae8",
-                "reference": "4239a9b107c17547da91d76005c996f08e164ae8",
+                "url": "https://api.github.com/repos/fabpot/Twig-extensions/zipball/v1.0.0",
+                "reference": "v1.0.0",
                 "shasum": ""
             },
             "require": {
-                "twig/twig": ">=1.0,<2.0"
+                "twig/twig": "1.*"
             },
             "type": "library",
             "extra": {
@@ -4579,7 +4595,7 @@
                 "i18n",
                 "text"
             ],
-            "time": "2013-06-07 09:36:35"
+            "time": "2013-02-28 14:21:30"
         },
         {
             "name": "twig/twig",
@@ -5004,7 +5020,8 @@
         "jackalope/jackalope-jackrabbit": 10,
         "sonata-project/doctrine-phpcr-admin-bundle": 15,
         "symfony-cmf/routing-auto-bundle": 15,
-        "symfony-cmf/blog-bundle": 15
+        "symfony-cmf/blog-bundle": 15,
+        "symfony-cmf/media-bundle": 20
     },
     "platform": {
         "php": ">=5.3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "6747d0578774ef0b76255143e3a861f3",
+    "hash": "646371fbb6d94567135c05eb23de6de0",
     "packages": [
         {
             "name": "aferrandini/urlizer",
@@ -709,6 +709,80 @@
             "time": "2013-03-07 12:15:25"
         },
         {
+            "name": "doctrine/orm",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/doctrine2.git",
+                "reference": "4e8b787d072fe48e798a1bd5cd05f08e9a083525"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/4e8b787d072fe48e798a1bd5cd05f08e9a083525",
+                "reference": "4e8b787d072fe48e798a1bd5cd05f08e9a083525",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/collections": ">=1.1,<2.0",
+                "doctrine/dbal": ">=2.4-beta,<2.5-dev",
+                "ext-pdo": "*",
+                "php": ">=5.3.2",
+                "symfony/console": "2.*"
+            },
+            "require-dev": {
+                "symfony/yaml": "2.1"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
+            },
+            "bin": [
+                "bin/doctrine",
+                "bin/doctrine.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\ORM\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com",
+                    "homepage": "http://www.instaclick.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                }
+            ],
+            "description": "Object-Relational-Mapper for PHP",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "orm"
+            ],
+            "time": "2013-05-28 07:36:17"
+        },
+        {
             "name": "doctrine/phpcr-bundle",
             "version": "1.0.0-alpha4",
             "target-dir": "Doctrine/Bundle/PHPCRBundle",
@@ -1071,6 +1145,53 @@
                 "rest"
             ],
             "time": "2013-05-06 10:33:17"
+        },
+        {
+            "name": "imagine/imagine",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/avalanche123/Imagine",
+                "reference": "v0.4.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/avalanche123/Imagine/archive/v0.4.1.zip",
+                "reference": "v0.4.1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "sami/sami": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Imagine": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bulat Shakirzyanov",
+                    "email": "mallluhuct@gmail.com",
+                    "homepage": "http://avalanche123.com"
+                }
+            ],
+            "description": "Image processing for PHP 5.3",
+            "homepage": "http://imagine.readthedocs.org/",
+            "keywords": [
+                "drawing",
+                "graphics",
+                "image manipulation",
+                "image processing"
+            ],
+            "time": "2012-12-13 18:31:18"
         },
         {
             "name": "jackalope/jackalope",
@@ -1696,6 +1817,81 @@
             "time": "2013-06-10 06:27:25"
         },
         {
+            "name": "knplabs/gaufrette",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/Gaufrette.git",
+                "reference": "4bfc8e16086276134768159093e2f5d2ad752991"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/Gaufrette/zipball/4bfc8e16086276134768159093e2f5d2ad752991",
+                "reference": "4bfc8e16086276134768159093e2f5d2ad752991",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "amazonwebservices/aws-sdk-for-php": "1.5.*",
+                "doctrine/dbal": ">=2.3",
+                "dropbox-php/dropbox-php": "*",
+                "herzult/php-ssh": "*",
+                "phpspec/phpspec2": "dev-master",
+                "phpunit/phpunit": "3.7.*",
+                "rackspace/php-cloudfiles": "*",
+                "rackspace/php-opencloud": "dev-master"
+            },
+            "suggest": {
+                "amazonwebservices/aws-sdk-for-php": "to use the Amazon S3 adapter",
+                "doctrine/dbal": "to use the Doctrine DBAL adapter",
+                "dropbox-php/dropbox-php": "to use the Dropbox adapter",
+                "ext-apc": "to use the APC adapter",
+                "ext-curl": "*",
+                "ext-fileinfo": "*",
+                "ext-mbstring": "*",
+                "ext-mongo": "*",
+                "ext-zip": "to use the Zip adapter",
+                "knplabs/knp-gaufrette-bundle": "*",
+                "rackspace/php-opencloud": "to use Opencloud adapter"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Gaufrette": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "The contributors",
+                    "homepage": "http://github.com/knplabs/Gaufrette/contributors"
+                },
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                }
+            ],
+            "description": "PHP5 library that provides a filesystem abstraction layer",
+            "homepage": "http://knplabs.com",
+            "keywords": [
+                "abstraction",
+                "file",
+                "filesystem",
+                "media"
+            ],
+            "time": "2013-04-28 21:52:32"
+        },
+        {
             "name": "knplabs/knp-menu",
             "version": "1.1.x-dev",
             "source": {
@@ -1880,6 +2076,54 @@
             "time": "2013-06-06 22:11:45"
         },
         {
+            "name": "kriswallsmith/buzz",
+            "version": "v0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kriswallsmith/Buzz.git",
+                "reference": "v0.10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kriswallsmith/Buzz/zipball/v0.10",
+                "reference": "v0.10",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
+            "suggest": {
+                "ext-curl": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Buzz": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kris Wallsmith",
+                    "email": "kris.wallsmith@gmail.com",
+                    "homepage": "http://kriswallsmith.net/"
+                }
+            ],
+            "description": "Lightweight HTTP client",
+            "homepage": "https://github.com/kriswallsmith/Buzz",
+            "keywords": [
+                "curl",
+                "http client"
+            ],
+            "time": "2013-05-19 03:41:15"
+        },
+        {
             "name": "liip/functional-test-bundle",
             "version": "dev-master",
             "target-dir": "Liip/FunctionalTestBundle",
@@ -1934,6 +2178,65 @@
                 "Symfony2"
             ],
             "time": "2013-05-24 05:48:28"
+        },
+        {
+            "name": "liip/imagine-bundle",
+            "version": "dev-develop",
+            "target-dir": "Liip/ImagineBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/liip/LiipImagineBundle.git",
+                "reference": "62aafe5ace667e110dcf74de91c74e79cee662ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/62aafe5ace667e110dcf74de91c74e79cee662ea",
+                "reference": "62aafe5ace667e110dcf74de91c74e79cee662ea",
+                "shasum": ""
+            },
+            "require": {
+                "imagine/imagine": "0.4.*",
+                "php": ">=5.3.2",
+                "symfony/filesystem": ">=2.0.16.0,>=2.0,<3.0",
+                "symfony/finder": ">=2.0.16.0,>=2.0,<3.0",
+                "symfony/framework-bundle": ">=2.0.16.0,>=2.0,<3.0",
+                "symfony/options-resolver": ">=2.0.16.0,>=2.0,<3.0"
+            },
+            "require-dev": {
+                "symfony/yaml": ">=2.0.16.0,>=2.0,<3.0",
+                "twig/twig": ">=1.0,<2.0-dev"
+            },
+            "suggest": {
+                "twig/twig": ">=1.0,<2.0-dev"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Liip\\ImagineBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Liip and other contributors",
+                    "homepage": "https://github.com/liip/LiipImagineBundle/contributors"
+                }
+            ],
+            "description": "This Bundle assists in imagine manipulation using the imagine library",
+            "homepage": "http://liip.ch",
+            "keywords": [
+                "image",
+                "imagine"
+            ],
+            "time": "2013-05-29 11:52:47"
         },
         {
             "name": "liip/search-bundle",
@@ -2754,6 +3057,54 @@
             "time": "2013-05-21 16:17:14"
         },
         {
+            "name": "sonata-project/doctrine-extensions",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sonata-project/sonata-doctrine-extensions.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sonata-project/sonata-doctrine-extensions/zipball/1.0.0",
+                "reference": "1.0.0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/orm": "*",
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sonata\\Doctrine\\Types": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Rabaix",
+                    "email": "thomas.rabaix@sonata-project.org",
+                    "homepage": "http://sonata-project.org"
+                },
+                {
+                    "name": "Sonata Community",
+                    "homepage": "https://github.com/sonata-project/sonata-doctrine-extensions/contributors"
+                }
+            ],
+            "description": "Doctrine2 behavioral extensions",
+            "homepage": "https://github.com/sonata-project/sonata-doctrine-extensions",
+            "keywords": [
+                "doctrine",
+                "doctrine2",
+                "json"
+            ],
+            "time": "2012-09-28 12:21:53"
+        },
+        {
             "name": "sonata-project/doctrine-phpcr-admin-bundle",
             "version": "1.0.0-alpha3",
             "target-dir": "Sonata/DoctrinePHPCRAdminBundle",
@@ -2814,6 +3165,62 @@
                 "sonata"
             ],
             "time": "2013-05-25 18:41:26"
+        },
+        {
+            "name": "sonata-project/easy-extends-bundle",
+            "version": "dev-master",
+            "target-dir": "Sonata/EasyExtendsBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sonata-project/SonataEasyExtendsBundle.git",
+                "reference": "19a63f38b0de28d8d69f320a368b2ad7c304716f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sonata-project/SonataEasyExtendsBundle/zipball/19a63f38b0de28d8d69f320a368b2ad7c304716f",
+                "reference": "19a63f38b0de28d8d69f320a368b2ad7c304716f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/console": "2.*",
+                "symfony/finder": "2.*",
+                "symfony/framework-bundle": "2.*"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.0": "2.0.x-dev",
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Sonata\\EasyExtendsBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Rabaix",
+                    "email": "thomas.rabaix@sonata-project.org",
+                    "homepage": "http://sonata-project.org"
+                },
+                {
+                    "name": "Sonata Community",
+                    "homepage": "https://github.com/sonata-project/SonataEasyExtendsBundle/contributors"
+                }
+            ],
+            "description": "Symfony SonataEasyExtendsBundle",
+            "homepage": "http://sonata-project.org/bundles/easy-extends",
+            "keywords": [
+                "Easy Extends",
+                "sonata"
+            ],
+            "time": "2013-03-01 16:21:38"
         },
         {
             "name": "sonata-project/exporter",
@@ -2916,6 +3323,147 @@
                 "sonata"
             ],
             "time": "2013-03-01 17:24:02"
+        },
+        {
+            "name": "sonata-project/media-bundle",
+            "version": "dev-master",
+            "target-dir": "Sonata/MediaBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sonata-project/SonataMediaBundle.git",
+                "reference": "24e9faa9a87824850762397671db7959f680187c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sonata-project/SonataMediaBundle/zipball/24e9faa9a87824850762397671db7959f680187c",
+                "reference": "24e9faa9a87824850762397671db7959f680187c",
+                "shasum": ""
+            },
+            "require": {
+                "imagine/imagine": "*@stable",
+                "knplabs/gaufrette": ">=0.1.4",
+                "kriswallsmith/buzz": "0.*",
+                "sonata-project/doctrine-extensions": "1.*",
+                "sonata-project/easy-extends-bundle": "2.1.*",
+                "sonata-project/notification-bundle": "2.2.*@dev",
+                "symfony/symfony": ">=2.2,<2.4-dev"
+            },
+            "require-dev": {
+                "amazonwebservices/aws-sdk-for-php": "1.5.*",
+                "sonata-project/doctrine-orm-admin-bundle": ">=2.2.1",
+                "sonata-project/formatter-bundle": "2.2.*@dev"
+            },
+            "suggest": {
+                "amazonwebservices/aws-sdk-for-php": "1.5.*",
+                "liip/imagine-bundle": "0.9.*",
+                "sonata-project/doctrine-orm-admin-bundle": ">=2.2.1"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.0": "2.0.x-dev",
+                    "dev-2.1": "2.1.x-dev",
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Sonata\\MediaBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Rabaix",
+                    "email": "thomas.rabaix@sonata-project.org",
+                    "homepage": "http://sonata-project.org"
+                },
+                {
+                    "name": "Sonata Community",
+                    "homepage": "https://github.com/sonata-project/SonataMediaBundle/contributors"
+                }
+            ],
+            "description": "Symfony SonataMediaBundle",
+            "homepage": "http://sonata-project.org/bundles/media",
+            "keywords": [
+                "dailymotion",
+                "file",
+                "media",
+                "pdf",
+                "sonata",
+                "upload",
+                "vimeo",
+                "youtube"
+            ],
+            "time": "2013-06-01 16:38:00"
+        },
+        {
+            "name": "sonata-project/notification-bundle",
+            "version": "dev-master",
+            "target-dir": "Sonata/NotificationBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sonata-project/SonataNotificationBundle.git",
+                "reference": "2.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sonata-project/SonataNotificationBundle/zipball/2.2.0",
+                "reference": "2.2.0",
+                "shasum": ""
+            },
+            "require": {
+                "sonata-project/doctrine-extensions": "1.*",
+                "symfony/symfony": ">=2.1,<2.4-dev"
+            },
+            "require-dev": {
+                "liip/monitor-bundle": "0.4.*",
+                "sonata-project/doctrine-orm-admin-bundle": "2.2.*",
+                "videlalvaro/php-amqplib": "2.0.*"
+            },
+            "suggest": {
+                "guzzle/guzzle": "3.*",
+                "liip/monitor-bundle": "0.4.*",
+                "sonata-project/doctrine-orm-admin-bundle": "2.2.*",
+                "videlalvaro/php-amqplib": "2.0.*"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Sonata\\NotificationBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Rabaix",
+                    "email": "thomas.rabaix@sonata-project.org",
+                    "homepage": "http://sonata-project.org"
+                },
+                {
+                    "name": "Sonata Community",
+                    "homepage": "https://github.com/sonata-project/SonataNotificationBundle/contributors"
+                }
+            ],
+            "description": "Symfony SonataNotificationBundle",
+            "homepage": "http://sonata-project.org/bundles/page",
+            "keywords": [
+                "cms",
+                "page",
+                "sonata"
+            ],
+            "time": "2013-06-01 13:34:36"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/Sandbox/BannerBundle/Admin/BannerImageAdmin.php
+++ b/src/Sandbox/BannerBundle/Admin/BannerImageAdmin.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Sandbox\BannerBundle\Admin;
+
+use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+
+class BannerImageAdmin extends Admin
+{
+//    protected $baseRouteName = 'sandbox_banner_image_admin';
+//    protected $baseRoutePattern = '/banner/banner_image';
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+//            ->add('name')
+            ->add('title', 'text', array('attr' => array('class' => '')))
+            ->add('description', 'textarea', array('attr' => array('class' => '')))
+            ->add('url', 'text', array('attr' => array('class' => '')))
+            ->add('image', 'sonata_type_model_list', array(), array('link_parameters' => array('context' => 'default')))
+            ->add('position', 'hidden')
+        ;
+    }
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('name')
+            ->add('title', 'text')
+            ->add('updated_at')
+        ;
+    }
+
+    protected function configureRoutes(RouteCollection $collection)
+    {
+        //$collection->remove('create');
+        $collection->remove('edit');
+        $collection->remove('delete');
+        $collection->remove('show');
+    }
+
+    public function getBatchActions()
+    {
+        return array();
+    }
+
+    public function getExportFormats()
+    {
+        return array();
+    }
+}

--- a/src/Sandbox/BannerBundle/Admin/ImageBlockAdmin.php
+++ b/src/Sandbox/BannerBundle/Admin/ImageBlockAdmin.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Sandbox\BannerBundle\Admin;
+
+use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sandbox\BannerBundle\Document\ImageBlock;
+
+class ImageBlockAdmin extends Admin
+{
+//    protected $baseRouteName = 'sandbox_banner_image_block_admin';
+//    protected $baseRoutePattern = '/banner/image_block';
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->add('parentDocument', 'doctrine_phpcr_odm_tree', array('choice_list' => array(), 'root_node' => $this->root, 'select_root_node' => true))
+            ->add('name')
+            ->add('items', 'sonata_type_collection', array('by_reference' => false, 'required' => false), array(
+                'edit' => 'inline',
+                'inline' => 'table',
+                'sortable'  => 'position',
+                'admin_code' => 'sandbox_banner.admin.banner_image'
+            ))
+        ;
+    }
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('id')
+            ->add('name')
+            ->add('updatedAt', 'datetime')
+        ;
+    }
+
+    public function getExportFormats()
+    {
+        return array();
+    }
+
+    public function getNewInstance()
+    {
+        /** @var $new ImageBlock */
+        $new = parent::getNewInstance();
+        if ($this->hasRequest()) {
+            $parentId = $this->getRequest()->query->get('parent');
+            if (null !== $parentId) {
+                $new->setParentDocument($this->getModelManager()->find(null, $parentId));
+            }
+        }
+        return $new;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prePersist($object)
+    {
+        // fix bug with annotations - PrePersist not being called
+        $object->reorderItems();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUpdate($object)
+    {
+        // fix bug with annotations - PreUpdate not being called
+        $object->reorderItems();
+    }
+}

--- a/src/Sandbox/BannerBundle/Block/MediaBlockService.php
+++ b/src/Sandbox/BannerBundle/Block/MediaBlockService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Sandbox\BannerBundle\Block;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\BlockBundle\Block\BaseBlockService;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class MediaBlockService extends BaseBlockService
+{
+    /**
+     * @var string
+     */
+    private $template = 'SandboxBannerBundle:Block:block_image.html.twig';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $form, BlockInterface $block)
+    {
+        throw new \RuntimeException('Not used at the moment, editing using a frontend or backend UI could be changed here');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+        throw new \RuntimeException('Not used at the moment, validation for editing using a frontend or backend UI could be changed here');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        if (!$response) {
+            $response = new Response();
+        }
+
+        $block = $blockContext->getBlock();
+
+        if ($block->getEnabled()) {
+            return $this->renderResponse($blockContext->getTemplate(), array(
+                'block'     => $block,
+                'items'     => $block->getItems()->slice(0, $blockContext->getSetting('maxItems')),
+                'settings'  => $blockContext->getSettings(),
+            ), $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string $template
+     */
+    public function setTemplate($template)
+    {
+        $this->template = $template;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'template' => $this->template,
+            'maxItems' => 4
+        ));
+    }
+}

--- a/src/Sandbox/BannerBundle/DependencyInjection/Configuration.php
+++ b/src/Sandbox/BannerBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sandbox\BannerBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('sandbox_banner');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/Sandbox/BannerBundle/DependencyInjection/SandboxBannerExtension.php
+++ b/src/Sandbox/BannerBundle/DependencyInjection/SandboxBannerExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sandbox\BannerBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class SandboxBannerExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/src/Sandbox/BannerBundle/Document/BannerBlockInterface.php
+++ b/src/Sandbox/BannerBundle/Document/BannerBlockInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Sandbox\BannerBundle\Document;
+
+use Doctrine\Common\Collections\Collection;
+use Sandbox\BannerBundle\Document\BannerImage;
+
+interface BannerBlockInterface
+{
+    /**
+     * Get items
+     *
+     * @return Collection
+     */
+    function getItems();
+
+    /**
+     * Set items
+     *
+     * @param Collection $items
+     */
+    function setItems(Collection $items);
+
+    /**
+     * Add a BannerImage to this block
+     *
+     * @param  BannerImage $item
+     * @param  string $key OPTIONAL
+     * @return boolean
+     */
+    function addItem(BannerImage $item, $key = null);
+
+    /**
+     * Remove a BannerImage from this block
+     *
+     * @param BannerImage $item
+     * @param null $key
+     * @return boolean
+     */
+    function removeItem(BannerImage $item, $key = null);
+}

--- a/src/Sandbox/BannerBundle/Document/BannerImage.php
+++ b/src/Sandbox/BannerBundle/Document/BannerImage.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Sandbox\BannerBundle\Document;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Sandbox\BannerBundle\Document\BannerBlockInterface;
+use Sandbox\MediaBundle\Document\Media;
+
+/**
+ * Document that contains a Media and additional banner information
+ *
+ * @PHPCRODM\Document(referenceable=true)
+ */
+class BannerImage
+{
+    /**
+     * @PHPCRODM\Id(strategy="parent")
+     */
+    protected $id;
+
+    /**
+     * @PHPCRODM\Nodename
+     */
+    protected $name;
+
+    /**
+     * @PHPCRODM\ParentDocument
+     */
+    protected $parentDocument;
+
+    /**
+     * @PHPCRODM\String
+     */
+    protected $title;
+
+    /**
+     * @PHPCRODM\String
+     */
+    protected $description;
+
+    /**
+     * @PHPCRODM\String
+     */
+    protected $url;
+
+    /**
+     * @PHPCRODM\ReferenceOne(strategy="weak", targetDocument="Sandbox\MediaBundle\Document\Media")
+     */
+    protected $image;
+
+    /**
+     * @var integer
+     */
+    protected $position;
+
+    /**
+     * @PHPCRODM\Date()
+     */
+    protected $createdAt;
+
+    /**
+     * @PHPCRODM\Date()
+     */
+    protected $updatedAt;
+
+    public function __toString()
+    {
+        return $this->getTitle() ? $this->getTitle() : $this->getName();
+    }
+
+    /**
+     * Get id
+     *
+     * @return string $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set name
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Get name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set parent document
+     *
+     * @param object $parent
+     */
+    public function setParentDocument(BannerBlockInterface $parent)
+    {
+        $this->parentDocument = $parent;
+    }
+
+    /**
+     * Get the parent document
+     *
+     * @return object|null $document
+     */
+    public function getParentDocument()
+    {
+        return $this->parentDocument;
+    }
+
+    /**
+     * Set title
+     *
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Get title
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set description
+     *
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Get description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set url
+     *
+     * @param string $url
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * Get url
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Set image
+     *
+     * @param Media $image
+     */
+    public function setImage(Media $image)
+    {
+        $this->image = $image;
+    }
+
+    /**
+     * Get image
+     *
+     * @return Media
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * Set position
+     *
+     * @param integer $position
+     */
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    /**
+     * Get position
+     *
+     * @return integer
+     */
+    public function getPosition()
+    {
+        return $this->position;
+
+//        $siblings = $this->getParentDocument()->getItems();
+//
+//        return array_search($siblings->indexOf($this), $siblings->getKeys());
+    }
+
+    /**
+     * Set createdAt
+     *
+     * @PHPCRODM\PrePersist()
+     * @param \Datetime $createdAt
+     */
+    public function setCreatedAt(\DateTime $createdAt = null)
+    {
+        $this->createdAt = is_null($createdAt) ? new \DateTime() : $createdAt;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \Datetime $createdAt
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * Set updatedAt
+     *
+     * @PHPCRODM\PrePersist()
+     * @PHPCRODM\PreUpdate()
+     * @param \Datetime $updatedAt
+     */
+    public function setUpdatedAt(\DateTime $updatedAt = null)
+    {
+        $this->updatedAt = is_null($updatedAt) ? new \DateTime() : $updatedAt;
+    }
+
+    /**
+     * Get updatedAt
+     *
+     * @return \Datetime $updatedAt
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+}

--- a/src/Sandbox/BannerBundle/Document/ImageBlock.php
+++ b/src/Sandbox/BannerBundle/Document/ImageBlock.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Sandbox\BannerBundle\Document;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Cmf\Bundle\BlockBundle\Document\BaseBlock;
+use Sandbox\BannerBundle\Document\BannerImage;
+
+/**
+ * Banner block that contains BannerImage documents
+ *
+ * @PHPCRODM\Document(referenceable=true)
+ */
+class ImageBlock extends BaseBlock implements BannerBlockInterface
+{
+    /** @PHPCRODM\Children() */
+    protected $items;
+
+    public function __construct()
+    {
+        $this->items = new ArrayCollection();
+    }
+
+    public function getType()
+    {
+        return 'sandbox_banner.block.image';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setItems(Collection $items)
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addItem(BannerImage $item, $key = null)
+    {
+        if (is_null($this->items)) {
+            $this->items = new ArrayCollection();
+        }
+
+        $item->setParentDocument($this);
+
+        // set nodename of BannerImage
+        if (!$item->getName()) {
+            $item->setName(
+                'image'.($this->items->count() + 1)
+            );
+        }
+
+        if ($key !== null) {
+            return $this->items->set($key, $item);
+        }
+
+        return $this->items->add($item);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function removeItem(BannerImage $item, $key = null)
+    {
+        if (is_null($this->items)) {
+            return false;
+        }
+
+        if ($key !== null) {
+            return $this->items->remove($key);
+        }
+
+        return $this->items->removeElement($item);
+    }
+
+    /**
+     * Reorders BannerImage items based on their position
+     *
+     * @PHPCRODM\PrePersist()
+     * @PHPCRODM\PreUpdate()
+     */
+    public function reorderItems()
+    {
+        if ($this->getItems() && $this->getItems() instanceof \IteratorAggregate) {
+
+            // reorder
+            $iterator = $this->getItems()->getIterator();
+
+            $iterator->uasort(function ($a, $b) {
+                if ($a->getPosition() === $b->getPosition()) {
+                    return 0;
+                }
+
+                return $a->getPosition() > $b->getPosition() ? 1 : -1;
+            });
+
+            $this->setItems(
+                new ArrayCollection(iterator_to_array($iterator))
+            );
+        }
+    }
+}

--- a/src/Sandbox/BannerBundle/Resources/Translations/BannerImageAdmin.en.yml
+++ b/src/Sandbox/BannerBundle/Resources/Translations/BannerImageAdmin.en.yml
@@ -1,0 +1,7 @@
+form:
+    label_name: Name
+    label_title: Title
+    label_description: Description
+    label_url: Url
+    label_image: Image
+    label_position: Position

--- a/src/Sandbox/BannerBundle/Resources/Translations/BannerImageAdmin.nl.yml
+++ b/src/Sandbox/BannerBundle/Resources/Translations/BannerImageAdmin.nl.yml
@@ -1,0 +1,7 @@
+form:
+    label_name: Naam
+    label_title: Titel
+    label_description: Beschrijving
+    label_url: Url
+    label_image: Afbeelding
+    label_position: Positie

--- a/src/Sandbox/BannerBundle/Resources/Translations/ImageBlockAdmin.en.yml
+++ b/src/Sandbox/BannerBundle/Resources/Translations/ImageBlockAdmin.en.yml
@@ -1,0 +1,18 @@
+dashboard:
+    label_banner_image_block: Image banner block
+
+breadcrumb:
+    link_image_block_list: Image banner blocks
+    link_image_block_create: Add new
+    link_image_block_edit: Edit
+    link_image_block_delete: Delete
+
+form:
+    label_parent_document: Parent page
+    label_name: Name
+    label_items: Images
+
+list:
+    label_id: Id
+    label_name: Name
+    label_updated_at: Updated at

--- a/src/Sandbox/BannerBundle/Resources/Translations/ImageBlockAdmin.nl.yml
+++ b/src/Sandbox/BannerBundle/Resources/Translations/ImageBlockAdmin.nl.yml
@@ -1,0 +1,18 @@
+dashboard:
+    label_banner_image_block: Afbeeldingen banner blok
+
+breadcrumb:
+    link_image_block_list: Afbeeldingen banner blokken
+    link_image_block_create: Nieuwe toevoegen
+    link_image_block_edit: Bewerken
+    link_image_block_delete: Verwijderen
+
+form:
+    label_parent_document: Bovenliggende pagina
+    label_name: Naam
+    label_items: Afbeeldingen
+
+list:
+    label_id: Id
+    label_name: Naam
+    label_updated_at: Aangepast op

--- a/src/Sandbox/BannerBundle/Resources/config/services.xml
+++ b/src/Sandbox/BannerBundle/Resources/config/services.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sandbox_banner.block.image.class">Sandbox\BannerBundle\Block\MediaBlockService</parameter>
+        <parameter key="sandbox_banner.admin.image_block.class">Sandbox\BannerBundle\Admin\ImageBlockAdmin</parameter>
+        <parameter key="sandbox_banner.image_block.class">Sandbox\BannerBundle\Document\ImageBlock</parameter>
+        <parameter key="sandbox_banner.admin.banner_image.class">Sandbox\BannerBundle\Admin\BannerImageAdmin</parameter>
+        <parameter key="sandbox_banner.banner_image.class">Sandbox\BannerBundle\Document\BannerImage</parameter>
+    </parameters>
+
+    <services>
+        <service id="sandbox_banner.block.image" class="%sandbox_banner.block.image.class%">
+            <tag name="sonata.block" />
+            <argument>sandbox_banner.block.image</argument>
+            <argument type="service" id="templating" />
+        </service>
+
+        <service id="sandbox_banner.admin.image_block" class="%sandbox_banner.admin.image_block.class%">
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="sandbox_banner" label="dashboard.label_banner_image_block" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument />
+            <argument>%sandbox_banner.image_block.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setRoot">
+                <argument>%cmf_content.content_basepath%</argument>
+            </call>
+            <call method="setTranslationDomain">
+                <argument>ImageBlockAdmin</argument>
+            </call>
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+        </service>
+
+        <service id="sandbox_banner.admin.banner_image" class="%sandbox_banner.admin.banner_image.class%">
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="sandbox_banner" label="label_banner_image" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <argument />
+            <argument>%sandbox_banner.banner_image.class%</argument>
+            <argument>SonataAdminBundle:CRUD</argument>
+
+            <call method="setTranslationDomain">
+                <argument>BannerImageAdmin</argument>
+            </call>
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
+            </call>
+        </service>
+    </services>
+</container>

--- a/src/Sandbox/BannerBundle/Resources/views/Block/block_image.html.twig
+++ b/src/Sandbox/BannerBundle/Resources/views/Block/block_image.html.twig
@@ -1,0 +1,11 @@
+{% extends 'SymfonyCmfBlockBundle:Block:block_base.html.twig' %}
+
+{% block block %}
+    <div class="image-banner-container">
+        <ul>
+        {% for item in items %}
+            <li>{{ item.title }} - {{ item.description }} - {% media item.image, 'small' with { 'class': 'slide' } %}</li>
+        {% endfor %}
+        </ul>
+    </div>
+{% endblock %}

--- a/src/Sandbox/BannerBundle/SandboxBannerBundle.php
+++ b/src/Sandbox/BannerBundle/SandboxBannerBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sandbox\BannerBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class SandboxBannerBundle extends Bundle
+{
+}

--- a/src/Sandbox/MainBundle/Resources/views/Homepage/index.html.twig
+++ b/src/Sandbox/MainBundle/Resources/views/Homepage/index.html.twig
@@ -9,11 +9,10 @@
 
     <hr/>
 
-    <div class="row">
-        {{ sonata_block_render({
-            'name': 'additionalInfoBlock'
-        }) }}
-    </div>
+    {{ sonata_block_render({ 'name': 'additionalInfoBlock' }, {
+        'divisibleBy': 3,
+        'divisibleClass': 'row'
+    }) }}
 
     <div class="row">
         <div class="span3">

--- a/src/Sandbox/MediaBundle/DataFixtures/PHPCR/LoadRootNodeData.php
+++ b/src/Sandbox/MediaBundle/DataFixtures/PHPCR/LoadRootNodeData.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Sandbox\MediaBundle\DataFixtures\PHPCR;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use PHPCR\Util\NodeHelper;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Symfony\Component\Yaml;
+
+use Symfony\Component\DependencyInjection\ContainerAware;
+
+class LoadRootNodeData extends ContainerAware implements FixtureInterface, OrderedFixtureInterface
+{
+
+    public function getOrder()
+    {
+        return 10;
+    }
+
+    /**
+     * Create default root node
+     *
+     * @param \Doctrine\ODM\PHPCR\DocumentManager $manager
+     */
+    public function load(ObjectManager $manager)
+    {
+        $session = $manager->getPhpcrSession();
+
+        // Create media root
+        $mediapath = $this->container->getParameter('sandbox_media.media_basepath');
+        $rootMedia = $manager->find(null, $mediapath);
+
+        if (!$rootMedia) {
+            $segments = preg_split('#/#', $mediapath, null, PREG_SPLIT_NO_EMPTY);
+
+            if (count($segments) > 1) {
+                $nodename = array_pop($segments);
+                $rootpath = '/'.join($segments, '/');
+            } else {
+                $nodename = $segments[0];
+                $rootpath = '/';
+            }
+
+            NodeHelper::createPath($session, $rootpath);
+            $root = $manager->find(null, $rootpath);
+
+            $rootMedia = new \Sandbox\MediaBundle\Document\MediaRoot();
+            $rootMedia->setParent($root);
+            $rootMedia->setNodename($nodename);
+
+            $manager->persist($rootMedia);
+            $manager->flush();
+        }
+
+        // Create gallery root
+        $gallerypath = $this->container->getParameter('sandbox_media.gallery_basepath');
+        $rootGallery = $manager->find(null, $gallerypath);
+
+        if (!$rootGallery) {
+            $segments = preg_split('#/#', $gallerypath, null, PREG_SPLIT_NO_EMPTY);
+
+            if (count($segments) > 1) {
+                $nodename = array_pop($segments);
+                $rootpath = '/'.join($segments, '/');
+            } else {
+                $nodename = $segments[0];
+                $rootpath = '/';
+            }
+
+            NodeHelper::createPath($session, $rootpath);
+            $root = $manager->find(null, $rootpath);
+
+            $rootGallery = new \Sandbox\MediaBundle\Document\GalleryRoot();
+            $rootGallery->setParent($root);
+            $rootGallery->setNodename($nodename);
+
+            $manager->persist($rootGallery);
+            $manager->flush();
+        }
+    }
+}

--- a/src/Sandbox/MediaBundle/DataFixtures/PHPCR/LoadRootNodeData.php
+++ b/src/Sandbox/MediaBundle/DataFixtures/PHPCR/LoadRootNodeData.php
@@ -25,6 +25,8 @@ class LoadRootNodeData extends ContainerAware implements FixtureInterface, Order
      */
     public function load(ObjectManager $manager)
     {
+        return;
+
         $session = $manager->getPhpcrSession();
 
         // Create media root

--- a/src/Sandbox/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sandbox/MediaBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sandbox\MediaBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+
+        $treeBuilder->root('sandbox_media')
+            ->children()
+                ->scalarNode('media_basepath')->defaultValue('/cms/media')->end()
+                ->scalarNode('gallery_basepath')->defaultValue('/cms/media_gallery')->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Sandbox/MediaBundle/DependencyInjection/SandboxMediaExtension.php
+++ b/src/Sandbox/MediaBundle/DependencyInjection/SandboxMediaExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sandbox\MediaBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class SandboxMediaExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+
+        $container->setParameter($this->getAlias() . '.media_basepath', $config['media_basepath']);
+        $container->setParameter($this->getAlias() . '.gallery_basepath', $config['gallery_basepath']);
+    }
+}

--- a/src/Sandbox/MediaBundle/Document/Gallery.php
+++ b/src/Sandbox/MediaBundle/Document/Gallery.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Sonata\MediaBundle\PHPCR\BaseGallery;
+
+class Gallery extends BaseGallery
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * The basepath of the id
+     *
+     * @var string
+     */
+    protected $idPrefix;
+
+    /**
+     * Get id
+     *
+     * @return string $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the basepath of the id
+     *
+     * @return string
+     */
+    public function getIdPrefix()
+    {
+        return $this->idPrefix;
+    }
+
+    /**
+     * Set the basepath of the id
+     *
+     * @param string $prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->idPrefix = $prefix;
+    }
+}

--- a/src/Sandbox/MediaBundle/Document/GalleryHasMedia.php
+++ b/src/Sandbox/MediaBundle/Document/GalleryHasMedia.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Sonata\MediaBundle\PHPCR\BaseGalleryHasMedia;
+
+class GalleryHasMedia extends BaseGalleryHasMedia
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * Get id
+     *
+     * @return string $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/src/Sandbox/MediaBundle/Document/GalleryRepository.php
+++ b/src/Sandbox/MediaBundle/Document/GalleryRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
+use JMS\DiExtraBundle\Annotation as DI;
+
+class GalleryRepository extends BaseDocumentRepository implements RepositoryIdInterface
+{
+    /**
+     * Generate a document id
+     *
+     * @param object $document
+     * @param object $parent
+     *
+     * @return string
+     */
+    public function generateId($document, $parent = null) {
+        $idPrefix = $document->getIdPrefix();
+
+        if (0 == strlen($idPrefix)) {
+            throw new \LogicException('Can not determine the prefix. Either this is a new, unpersisted document or the listener that calls setPrefix is not set up correctly.');
+        }
+
+        return $idPrefix.'/'.$document->getName();
+    }
+}

--- a/src/Sandbox/MediaBundle/Document/GalleryRoot.php
+++ b/src/Sandbox/MediaBundle/Document/GalleryRoot.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Doctrine\ODM\PHPCR\Document\Generic;
+
+class GalleryRoot extends Generic
+{
+
+}

--- a/src/Sandbox/MediaBundle/Document/Media.php
+++ b/src/Sandbox/MediaBundle/Document/Media.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Sonata\MediaBundle\PHPCR\BaseMedia;
+
+class Media extends BaseMedia
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * The basepath of the id
+     *
+     * @var string
+     */
+    protected $idPrefix;
+
+    /**
+     * Get id
+     *
+     * @return string $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the basepath of the id
+     *
+     * @return string
+     */
+    public function getIdPrefix()
+    {
+        return $this->idPrefix;
+    }
+
+    /**
+     * Set the basepath of the id
+     *
+     * @param string $prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->idPrefix = $prefix;
+    }
+}

--- a/src/Sandbox/MediaBundle/Document/MediaRepository.php
+++ b/src/Sandbox/MediaBundle/Document/MediaRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
+use JMS\DiExtraBundle\Annotation as DI;
+
+class MediaRepository extends BaseDocumentRepository implements RepositoryIdInterface
+{
+    /**
+     * Generate a document id
+     *
+     * @param object $document
+     * @param object $parent
+     *
+     * @return string
+     */
+    public function generateId($document, $parent = null) {
+        $idPrefix = $document->getIdPrefix();
+
+        if (0 == strlen($idPrefix)) {
+            throw new \LogicException('Can not determine the prefix. Either this is a new, unpersisted document or the listener that calls setPrefix is not set up correctly.');
+        }
+
+        return $idPrefix.'/'.$document->getProviderReference();
+    }
+}

--- a/src/Sandbox/MediaBundle/Document/MediaRoot.php
+++ b/src/Sandbox/MediaBundle/Document/MediaRoot.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Doctrine\ODM\PHPCR\Document\Generic;
+
+class MediaRoot extends Generic
+{
+
+}

--- a/src/Sandbox/MediaBundle/Listener/IdPrefix.php
+++ b/src/Sandbox/MediaBundle/Listener/IdPrefix.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sandbox\MediaBundle\Listener;
+
+use Doctrine\ODM\PHPCR\Event\LifecycleEventArgs;
+use Sonata\MediaBundle\PHPCR\BaseGallery;
+use Sonata\MediaBundle\PHPCR\BaseMedia;
+
+/**
+ * Doctrine PHPCR-ODM listener to set the idPrefix on new media and galleries
+ */
+class IdPrefix
+{
+    /**
+     * The prefix to add to the media to create the repository path
+     *
+     * @var string
+     */
+    protected $mediaIdPrefix = '';
+
+    /**
+     * The prefix to add to the gallery to create the repository path
+     *
+     * @var string
+     */
+    protected $galleryIdPrefix = '';
+
+    public function __construct($mediaPrefix, $galleryPrefix = '')
+    {
+        $this->mediaIdPrefix = $mediaPrefix;
+        $this->galleryIdPrefix = $galleryPrefix;
+    }
+
+    /**
+     * @param $prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->idPrefix = $prefix;
+    }
+
+    public function postLoad(LifecycleEventArgs $args)
+    {
+        $this->updateId($args);
+    }
+
+    public function prePersist(LifecycleEventArgs $args)
+    {
+        $this->updateId($args);
+    }
+
+    protected function updateId(LifecycleEventArgs $args)
+    {
+        $doc = $args->getDocument();
+
+        if ($doc instanceof BaseMedia) {
+            $doc->setPrefix($this->mediaIdPrefix);
+        }
+
+        if ($doc instanceof BaseGallery) {
+            $doc->setPrefix($this->galleryIdPrefix);
+        }
+    }
+}

--- a/src/Sandbox/MediaBundle/Resources/config/doctrine/Gallery.phpcr.xml
+++ b/src/Sandbox/MediaBundle/Resources/config/doctrine/Gallery.phpcr.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-phpcr-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Sandbox\MediaBundle\Document\Gallery"
+              repository-class="Sandbox\MediaBundle\Document\GalleryRepository"
+              referenceable="true" >
+
+        <id name="id" type="id">
+            <generator strategy="repository" />
+        </id>
+
+    </document>
+
+</doctrine-phpcr-mapping>

--- a/src/Sandbox/MediaBundle/Resources/config/doctrine/GalleryHasMedia.phpcr.xml
+++ b/src/Sandbox/MediaBundle/Resources/config/doctrine/GalleryHasMedia.phpcr.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-phpcr-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Sandbox\MediaBundle\Document\GalleryHasMedia" referenceable="true" >
+
+        <reference-one fieldName="media" strategy="weak" targetDocument="Sandbox\MediaBundle\Document\Media" />
+
+        <id name="id" type="id">
+            <generator strategy="parent" />
+        </id>
+
+    </document>
+
+</doctrine-phpcr-mapping>

--- a/src/Sandbox/MediaBundle/Resources/config/doctrine/GalleryRoot.phpcr.xml
+++ b/src/Sandbox/MediaBundle/Resources/config/doctrine/GalleryRoot.phpcr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-phpcr-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Sandbox\MediaBundle\Document\GalleryRoot" />
+
+</doctrine-phpcr-mapping>

--- a/src/Sandbox/MediaBundle/Resources/config/doctrine/Media.phpcr.xml
+++ b/src/Sandbox/MediaBundle/Resources/config/doctrine/Media.phpcr.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-phpcr-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Sandbox\MediaBundle\Document\Media"
+              repository-class="Sandbox\MediaBundle\Document\MediaRepository"
+              referenceable="true" >
+
+        <id name="id" type="id">
+            <generator strategy="repository" />
+        </id>
+    </document>
+
+</doctrine-phpcr-mapping>

--- a/src/Sandbox/MediaBundle/Resources/config/doctrine/MediaRoot.phpcr.xml
+++ b/src/Sandbox/MediaBundle/Resources/config/doctrine/MediaRoot.phpcr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-phpcr-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <document name="Sandbox\MediaBundle\Document\MediaRoot" />
+
+</doctrine-phpcr-mapping>

--- a/src/Sandbox/MediaBundle/Resources/config/services.xml
+++ b/src/Sandbox/MediaBundle/Resources/config/services.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sandbox_media.id_prefix_listener.class">Sandbox\MediaBundle\Listener\IdPrefix</parameter>
+    </parameters>
+
+    <services>
+        <service id="sandbox_media.id_prefix_listener" class="%sandbox_media.id_prefix_listener.class%">
+            <argument>%sandbox_media.media_basepath%</argument>
+            <argument>%sandbox_media.gallery_basepath%</argument>
+            <tag name="doctrine_phpcr.event_listener" event="postLoad" />
+            <tag name="doctrine_phpcr.event_listener" event="prePersist" />
+        </service>
+    </services>
+</container>

--- a/src/Sandbox/MediaBundle/Resources/config/services.xml
+++ b/src/Sandbox/MediaBundle/Resources/config/services.xml
@@ -15,5 +15,14 @@
             <tag name="doctrine_phpcr.event_listener" event="postLoad" />
             <tag name="doctrine_phpcr.event_listener" event="prePersist" />
         </service>
+
+        <service id="liip_imagine.data.loader.phpcr" class="Liip\ImagineBundle\Imagine\Data\Loader\DoctrinePHPCRLoader">
+            <tag name="liip_imagine.data.loader" loader="doctrine_phpcr" />
+            <argument type="service" id="liip_imagine" />
+            <argument>%liip_imagine.formats%</argument>
+            <argument/>
+            <argument type="service" id="doctrine_phpcr.odm.document_manager" />
+            <argument>Doctrine\ODM\PHPCR\Document\Image</argument>
+        </service>
     </services>
 </container>

--- a/src/Sandbox/MediaBundle/Resources/translations/SonataAdminBundle.en.yml
+++ b/src/Sandbox/MediaBundle/Resources/translations/SonataAdminBundle.en.yml
@@ -1,0 +1,1 @@
+group.media: Media library

--- a/src/Sandbox/MediaBundle/Resources/translations/SonataAdminBundle.nl.yml
+++ b/src/Sandbox/MediaBundle/Resources/translations/SonataAdminBundle.nl.yml
@@ -1,0 +1,1 @@
+group.media: Media bibliotheek

--- a/src/Sandbox/MediaBundle/SandboxMediaBundle.php
+++ b/src/Sandbox/MediaBundle/SandboxMediaBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sandbox\MediaBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class SandboxMediaBundle extends Bundle
+{
+}


### PR DESCRIPTION
This PR adds an example implementation for the SonataMediaBundle.

Related to:
* https://github.com/sonata-project/SonataMediaBundle/pull/271 (merged)
* https://github.com/sonata-project/SonataMediaBundle/pull/272 (merged)
* https://github.com/sonata-project/SonataMediaBundle/pull/273
* https://github.com/sonata-project/SonataAdminBundle/pull/1178 (merged)

Questions:
* No frontend example is added, what do we add?
  * a banner with sponsor logo's could be added or a slide show with a short intro etc.
  * will there also be an example created for the [SlideshowBlock](https://github.com/symfony-cmf/BlockBundle/pull/32)? Then the examples should be in sync, maybe devided or each example has several implementations.
  * for media fixtures see the object sharing issue mentioned underneath
* "web/media/cache" dir for LiipImagineBundle is not automatically created + permissions have to be set for "web/uploads", document that this has to be done? see also ["Setting up Permissions"](http://symfony.com/doc/current/book/installation.html#configuration-and-setup)

The following subjects / issues I could not solve:
* fix bug with annotations - PrePersist/PreUpdate not being called, see:
[here] (https://github.com/beeldspraak/cmf-sandbox/blob/sonata_media/src/Sandbox/BannerBundle/Admin/ImageBlockAdmin.php#L61)
and [here](https://github.com/beeldspraak/cmf-sandbox/blob/sonata_media/src/Sandbox/BannerBundle/Document/ImageBlock.php#L91)
* <del>jackrabbit (works with dbal) ReferenceOne to media: "ConstraintViolationException: HTTP 409: Unable to perform operation. Node is protected. ", see: 
[here](https://github.com/beeldspraak/cmf-sandbox/blob/sonata_media/src/Sandbox/BannerBundle/Document/BannerImage.php#L47)
and [here](https://github.com/beeldspraak/cmf-sandbox/blob/sonata_media/src/Sandbox/MediaBundle/Resources/config/doctrine/GalleryHasMedia.phpcr.xml#L9)</del> - running jackrabbit 2.6.0 seems to solve this
* doctrine configuration referenceable="true" is not detected on mapped-superclass, has to be defined on the document extending the mapper superclass
* Doctrine PHPCR DataFixtures cannot share objects between fixtures, as described [here](http://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html#sharing-objects-between-fixtures)
* <del>Implement doctrine integration for PHPCR in JMSDIExtra to be able to inject base paths in Repository classes, see:
[here](https://github.com/beeldspraak/cmf-sandbox/blob/sonata_media/src/Sandbox/MediaBundle/Document/MediaRepository.php#L18)
, [here](https://github.com/beeldspraak/cmf-sandbox/blob/sonata_media/src/Sandbox/MediaBundle/Document/GalleryRepository.php#L18)
and [here](https://github.com/beeldspraak/cmf-sandbox/blob/sonata_media/app/config/config.yml#L351)
</del>