### PR TITLE
Add default blog_basepath for symfony_cmf_blog

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -129,6 +129,7 @@ symfony_cmf_menu:
 
 symfony_cmf_blog:
     routing_basepath: /cms/routes
+    blog_basepath: /cms/content
 
 sonata_block:
     default_contexts: [cms]


### PR DESCRIPTION
fixes #161 
