### PR TITLE
Update config.yml for BlockContext

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -139,7 +139,8 @@ sonata_block:
             settings:
                 id: '/cms'
             contexts:   [admin]
-        symfony_cmf.block.action:
+    blocks_by_class:
+        Symfony\Cmf\Bundle\BlockBundle\Document\RssBlock:
             cache: symfony_cmf.block.cache.js_async
 
 sonata_admin:


### PR DESCRIPTION
If the dependencies are updated to use the new BlockContext, the config needs to be updated.

This prevents all action blocks to be async cached and only configures caching for the rss block class.
