### PR TITLE
BUG-#39

### DIFF
--- a/src/Sandbox/MainBundle/Resources/views/skeleton.html.twig
+++ b/src/Sandbox/MainBundle/Resources/views/skeleton.html.twig
@@ -114,7 +114,7 @@
         </div>
 
         {% block bottom_scripts %}
-            {% render controller("cmf_create.jsloader.controller:includeJSFilesAction") %}
+            {% render controller("cmf_create.jsloader.controller:includeJSFilesAction",{ _locale: app.request.locale }) %}
         {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
fixes bug described here https://github.com/symfony-cmf/CreateBundle/issues/39

includejsfiles-create.html.twig rendered thru embedded controller will never get locale and will fallback to default one.
