### PR TITLE
MediaBundle + CreateBundle - enable persistence.phpcr

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -121,11 +121,18 @@ cmf_simple_cms:
             Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page:  CmfSimpleCmsBundle:Page:index.html.twig
 
 cmf_create:
-    phpcr_odm: true
     map:
         'http://rdfs.org/sioc/ns#Post': 'Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent'
+    persistence:
+        phpcr:
+            enabled: true
 
 cmf_block:
+    persistence:
+        phpcr:
+            enabled: true
+
+cmf_media:
     persistence:
         phpcr:
             enabled: true


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/191 |

To be merged when the configuration changes for the bundle standards for the MediaBundle and the CreateBundle are merged:
- https://github.com/symfony-cmf/MediaBundle/pull/41
- https://github.com/symfony-cmf/CreateBundle/pull/70
