### PR TITLE
Set default routes loaded by fixtures with prefered 'locale' parameter

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -7,7 +7,7 @@ home_redirect:
     pattern: /
     defaults:
         _controller: lunetics_locale.switcher_controller:switchAction
-        route: /cms/routes/en
+        route: /cms/routes/%locale%
         statusCode: 301
         useReferrer: false
 

--- a/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadRoutingData.php
+++ b/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadRoutingData.php
@@ -142,10 +142,11 @@ class LoadRoutingData extends ContainerAware implements FixtureInterface, Ordere
 
         // class to template mapping is used for all the rest
 
+        $default_locale = $this->container->getParameter('locale');
         $singlelocale = new Route;
-        $singlelocale->setPosition($dm->find(null, "$basepath/en"), 'singlelocale');
-        $singlelocale->setDefault('_locale', 'en');
-        $singlelocale->setRequirement('_locale', 'en');
+        $singlelocale->setPosition($dm->find(null, "$basepath/$default_locale"), 'singlelocale');
+        $singlelocale->setDefault('_locale', $default_locale);
+        $singlelocale->setRequirement('_locale', $default_locale);
         $singlelocale->setContent($dm->find(null, "$content_path/singlelocale"));
         $dm->persist($singlelocale);
 


### PR DESCRIPTION
Related to issues #200, i changed the default 'en' in fixtures and routes with 'locale' parameter as it allow user to define whatever 'locales' parameter. Even without english. 
