### PR TITLE
Added setup permissions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Run this to load the fixtures from the Sandbox MainBundle.
 
 As with any Symfony, you need to set up permissions.
 A good guide is at [Symfony2 installation guide](http://symfony.com/doc/current/book/installation.html#configuration-and-setup).
+If you use the default setup, an sqlite database will be created at `app/app.sqlite`.
+You need to set up permissions for this file and app/ folder as well.
 
-But if you are just want to move on for now or using sqlite database,
-run sudo chmod -R 777 on app/ folder.
+But if you are just want to move on for now run sudo chmod -R 777 on app/ folder.
 
 ## Access by web browser
 


### PR DESCRIPTION
I have added permissions setup installation step to README file. Discussed in Issue #206. Merge if you like it.
