### PR TITLE
enabled json/xml support

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,6 +24,7 @@ twig:
     form:
         resources:
             - 'CmfMediaBundle:Form:fields.html.twig'
+    exception_controller: 'FOS\RestBundle\Controller\ExceptionController::showAction'
 
 # Assetic Configuration
 assetic:
@@ -342,4 +343,4 @@ fos_rest:
         json: true
     format_listener:
         rules:
-            - { path: ^/, priorities: [ html, json, xml ], fallback_format: ~, prefer_extension: true }
+            - { path: ^/, priorities: [ html, json, xml ], fallback_format: html, prefer_extension: false }

--- a/app/tests/HomepageTest.php
+++ b/app/tests/HomepageTest.php
@@ -43,12 +43,13 @@ class HomepageTest extends WebTestCase
             array(),
             array(),
             array(
-                'CONTENT_TYPE'          => 'application/json',
+                'HTTP_ACCEPT'  => 'application/json',
+                'CONTENT_TYPE' => 'application/json'
             )
         );
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
 
         $json = @json_decode($client->getResponse()->getContent());
-        $this->assertTrue($json);
+        $this->assertNotEmpty($json);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "lunetics/locale-bundle": "2.2.*",
         "liip/imagine-bundle": "~0.12",
         "wjzijderveld/check-bundles": "1.0.*@dev",
-        "helios-ag/fm-elfinder-bundle": "~1.4"
+        "helios-ag/fm-elfinder-bundle": "~1.4",
+        "doctrine/phpcr-odm": "~1.0.1"
     },
     "require-dev": {
         "liip/functional-test-bundle": "1.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "c49d18d54f94c671c281982950ad10c7",
+    "hash": "ce76fa9079d944297dae351ad831a676",
     "packages": [
         {
             "name": "aferrandini/urlizer",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

the goal is to enable something like `curl http://cmf.lo/app_dev.php/en -H Accept:application/json`

this requires the following changes:
https://github.com/schmittjoh/serializer/pull/184 (released in 0.14.0)
https://github.com/schmittjoh/JMSSerializerBundle/pull/340 (released in 0.13.0)
https://github.com/doctrine/phpcr-odm/pull/378 (released in 1.0.1)
https://github.com/doctrine/phpcr-odm/pull/380 (released in 1.0.1)

this is not required but improves the output structure:
https://github.com/symfony-cmf/ContentBundle/pull/91 (merged into 1.1-dev)
