### PR TITLE
Add required package 'php5-gd' in cookbook

### DIFF
--- a/vagrant/cookbook/recipes/default.rb
+++ b/vagrant/cookbook/recipes/default.rb
@@ -37,6 +37,7 @@ git
 libapache2-mod-php5
 php5-cli
 php5-curl
+php5-gd
 php5-sqlite
 php5-intl
 php-apc


### PR DESCRIPTION
After installing using Vagrant, I got this error when trying to access app_dev.php:
`PHP Fatal error:  Uncaught exception 'Imagine\\Exception\\RuntimeException' with message 'Gd not installed' in /var/tmp/vendor/imagine/imagine/lib/Imagine/Gd/Imagine.php:42\nStack trace:\n#0 /var/tmp/vendor/imagine/imagine/lib/Imagine/Gd/Imagine.php(35): Imagine\\Gd\\Imagine->loadGdInfo()\n#1 /vagrant/app/cache/dev/appDevDebugProjectContainer.php(4713): Imagine\\Gd\\Imagine->__construct()\n#2 /vagrant/app/bootstrap.php.cache(1974): appDevDebugProjectContainer->getLiipImagineService()\n#3 /vagrant/app/cache/dev/appDevDebugProjectContainer.php(1794): Symfony\\Component\\DependencyInjection\\Container->get('liip_imagine')\n#4 /vagrant/app/bootstrap.php.cache(1974): appDevDebugProjectContainer->getCmfMedia_Persistence_Phpcr_Subscriber_ImageDimensionsService()\n#5 /vagrant/app/cache/dev/appDevDebugProjectContainer.php(3172): Symfony\\Component\\DependencyInjection\\Container->get('cmf_media.persi...')\n#6 /vagrant/app/bootstrap.php.cache(1974): appDevDebugProjectContainer->getDoctrinePhpcr_Odm_DefaultDocumentManagerService()\n#7 /var/tmp/vendor/symfony in /var/tmp/vendor/imagine/imagine/lib/Imagine/Gd/Imagine.php on line 42`

Installing `php5-gd` package fixed this, so I think it should be in the cookbook.
