### PR TITLE
use the console not the bin directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,9 +62,6 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets"
         ]
     },
-    "config": {
-        "bin-dir": "bin"
-    },
     "extra": {
         "checkbundles-ignore": [
             "Liip\\FunctionalTestBundle\\LiipFunctionalTestBundle",


### PR DESCRIPTION
there is no value in mapping the provided binaries into the project - they can live in vendor/bin as we do not need them anyways.
