### PR TITLE
demo of content negotiation and rest handling

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -322,6 +322,14 @@ doctrine_cache:
         phpcr_nodes:
             type: file_system
 
+jms_serializer:
+    metadata:
+        auto_detection: true
+        directories:
+            CmfContentBundle:
+                namespace_prefix: "Symfony\Cmf\Bundle\ContentBundle"
+                path: "@SandboxMainBundle/Resources/config/serializer/cmf"
+
 fos_rest:
     view:
         force_redirects:
@@ -336,4 +344,5 @@ fos_rest:
         json: true
     format_listener:
         rules:
+            - { path: ^/../company/team, priorities: [ html, json, xml, css ], fallback_format: html, prefer_extension: true }
             - { path: ^/, priorities: [ html, json, xml, css ], fallback_format: html, prefer_extension: false }

--- a/app/tests/HomepageTest.php
+++ b/app/tests/HomepageTest.php
@@ -29,7 +29,7 @@ class HomepageTest extends WebTestCase
         $this->assertCount(1, $crawler->filter('h1:contains(Homepage)'));
         $this->assertCount(1, $crawler->filter('h2:contains("Welcome to the Symfony CMF Demo")'));
 
-        $menuCount = $this->isSearchSupported() ? 21 : 20;
+        $menuCount = $this->isSearchSupported() ? 23 : 22;
         $this->assertCount($menuCount, $crawler->filter('ul.menu_main li'));
     }
 

--- a/app/tests/StaticPageTest.php
+++ b/app/tests/StaticPageTest.php
@@ -35,4 +35,17 @@ class StaticPageTest extends WebTestCase
             array('/about', 'Some information about us'),
         );
     }
+
+    public function testJson()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/de/company/team.json');
+        $response = $client->getResponse();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue(
+            $response->headers->contains('Content-Type', 'application/json'),
+            $response->headers
+        );
+        $this->assertContains('"title":"The Team",', $response->getContent());
+    }
 }

--- a/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadMenuData.php
+++ b/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadMenuData.php
@@ -51,6 +51,10 @@ class LoadMenuData extends ContainerAware implements FixtureInterface, OrderedFi
 
         $company = $this->createMenuNode($dm, $main, 'company-item', array('en' => 'Company', 'de' => 'Firma', 'fr' => 'Entreprise'), $dm->find(null, "$content_path/company"));
         $this->createMenuNode($dm, $company, 'team-item', array('en' => 'Team', 'de' => 'Team', 'fr' => 'Equipe'), $dm->find(null, "$content_path/team"));
+        $team = $this->createMenuNode($dm, $company, 'team-json-item', array('en' => 'Team (json)', 'de' => 'Team (json)', 'fr' => 'Equipe (json)'), $dm->find(null, "$content_path/team"));
+        $team->setRouteParameters(array('_format' => 'json'));
+        $team = $this->createMenuNode($dm, $company, 'team-xml-item', array('en' => 'Team (xml)', 'de' => 'Team (xml)', 'fr' => 'Equipe (xml)'), $dm->find(null, "$content_path/team"));
+        $team->setRouteParameters(array('_format' => 'xml'));
         $this->createMenuNode($dm, $company, 'more-item', array('en' => 'More', 'de' => 'Mehr', 'fr' => 'Plus'), $dm->find(null, "$content_path/more"));
 
         $demo = $this->createMenuNode($dm, $main, 'demo-item', 'Demo', $dm->find(null, "$content_path/demo"));

--- a/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadRoutingData.php
+++ b/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadRoutingData.php
@@ -56,8 +56,12 @@ class LoadRoutingData extends ContainerAware implements FixtureInterface, Ordere
             $company->setContent($dm->find(null, "$content_path/company"));
             $dm->persist($company);
 
+            // special route that also supports adding the format as a parameter
             $team = new Route;
             $team->setPosition($company, 'team');
+            $team->setOption('add_format_pattern', true);
+            $team->setDefault('_format', 'html');
+            $team->setRequirement('_format', 'html|json|xml');
             $team->setContent($dm->find(null, "$content_path/team"));
             $dm->persist($team);
 

--- a/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadStaticPageData.php
+++ b/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadStaticPageData.php
@@ -6,6 +6,7 @@ use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
+use Doctrine\ODM\PHPCR\DocumentManager;
 use PHPCR\Util\NodeHelper;
 
 use Sandbox\MainBundle\Document\DemoSeoContent;
@@ -20,6 +21,9 @@ class LoadStaticPageData extends ContainerAware implements FixtureInterface, Ord
         return 5;
     }
 
+    /**
+     * @param DocumentManager $manager
+     */
     public function load(ObjectManager $manager)
     {
         $session = $manager->getPhpcrSession();

--- a/src/Sandbox/MainBundle/Resources/config/serializer/Document.DemoSeoContent.yml
+++ b/src/Sandbox/MainBundle/Resources/config/serializer/Document.DemoSeoContent.yml
@@ -1,0 +1,2 @@
+Sandbox\MainBundle\Document\DemoSeoContent:
+    exclusion_policy: ALL

--- a/src/Sandbox/MainBundle/Resources/config/serializer/cmf/Model.StaticContent.yml
+++ b/src/Sandbox/MainBundle/Resources/config/serializer/cmf/Model.StaticContent.yml
@@ -1,0 +1,2 @@
+Symfony\Cmf\Bundle\ContentBundle\Model\StaticContent:
+    exclusion_policy: ALL

--- a/src/Sandbox/MainBundle/Resources/data/page.yml
+++ b/src/Sandbox/MainBundle/Resources/data/page.yml
@@ -65,10 +65,14 @@ static:
         body: |
             <h2>Our Team</h2>
             <p>There are some core developers and many other contributors. We need more help, so please contribute.</p>
-            <h2>dicta facete eu vis</h2>
-            <p>Sonet affert an has. Nam id odio nisl eruditi. Te quo falli propriae delectus, ut animal meliore est, agam decore in sea. Prima debet fierent id sed. Usu debet paulo argumentum ex, solum homero in sed, modus laboramus et usu. Brute legendos contentiones ex pri.
 
-            Ut suscipit honestatis sed, per id facer euismod probatus. Ne persius posidonium eum, has elaboraret philosophia eu. No eam wisi choro labores. Sit id oratio aperiam electram, quodsi deterruisset no eum, vel modo quaeque ei</p>
+            <h2>REST example</h2>
+
+            <p>The route for this page also supports adding ".json" or ".xml" to the end in order to get a JSON or XML
+            rendered version. However actually the CMF also fully supports Accept header based content negotiation. So
+            using 'curl -H "Accept: application/json" http://cmf-sandbox.lo/app_dev.php/en/company/team' would work just
+            as well. In fact the sandbox is configured that it is possible to get an JSON/XML representation of all
+            content pages. For example 'curl -H "Accept: application/xml" http://cmf-sandbox.lo/app_dev.php/en'</p>
         blocks:
             additionalInfoBlock:
                 class: Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ContainerBlock


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #202 |
| License | MIT |
| Doc PR | - |

This is to demo the _format operations in a simplistic case. Do we need anything more here, document somehow why or how we do it? http://symfony.com/doc/master/cmf/bundles/content/exposing_content_via_rest.html seems to pretty much cover it.

<rant-on>
I spent most of the time figuring out how to make the jms serializer work as expected. the doc is extremly vague as to how to overwrite configuration from other bundles, and how to name files and such things. this is what finally worked, after reading a bunch of random stackoverflow questions and trying things out.
</rant-on>
