### PR TITLE
change content negotiation example to be more standard

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -344,5 +344,4 @@ fos_rest:
         json: true
     format_listener:
         rules:
-            - { path: ^/../company/team, priorities: [ html, json, xml, css ], fallback_format: html, prefer_extension: true }
             - { path: ^/, priorities: [ html, json, xml, css ], fallback_format: html, prefer_extension: false }

--- a/app/tests/HomepageTest.php
+++ b/app/tests/HomepageTest.php
@@ -29,7 +29,7 @@ class HomepageTest extends WebTestCase
         $this->assertCount(1, $crawler->filter('h1:contains(Homepage)'));
         $this->assertCount(1, $crawler->filter('h2:contains("Welcome to the Symfony CMF Demo")'));
 
-        $menuCount = $this->isSearchSupported() ? 23 : 22;
+        $menuCount = $this->isSearchSupported() ? 21 : 20;
         $this->assertCount($menuCount, $crawler->filter('ul.menu_main li'));
     }
 

--- a/app/tests/StaticPageTest.php
+++ b/app/tests/StaticPageTest.php
@@ -39,7 +39,10 @@ class StaticPageTest extends WebTestCase
     public function testJson()
     {
         $client = $this->createClient();
-        $client->request('GET', '/de/company/team.json');
+        $client->request('GET', '/de/company/team', array(), array(), array(
+                'HTTP_ACCEPT'  => 'application/json',
+            )
+        );
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertTrue(

--- a/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadMenuData.php
+++ b/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadMenuData.php
@@ -51,10 +51,6 @@ class LoadMenuData extends ContainerAware implements FixtureInterface, OrderedFi
 
         $company = $this->createMenuNode($dm, $main, 'company-item', array('en' => 'Company', 'de' => 'Firma', 'fr' => 'Entreprise'), $dm->find(null, "$content_path/company"));
         $this->createMenuNode($dm, $company, 'team-item', array('en' => 'Team', 'de' => 'Team', 'fr' => 'Equipe'), $dm->find(null, "$content_path/team"));
-        $team = $this->createMenuNode($dm, $company, 'team-json-item', array('en' => 'Team (json)', 'de' => 'Team (json)', 'fr' => 'Equipe (json)'), $dm->find(null, "$content_path/team"));
-        $team->setRouteParameters(array('_format' => 'json'));
-        $team = $this->createMenuNode($dm, $company, 'team-xml-item', array('en' => 'Team (xml)', 'de' => 'Team (xml)', 'fr' => 'Equipe (xml)'), $dm->find(null, "$content_path/team"));
-        $team->setRouteParameters(array('_format' => 'xml'));
         $this->createMenuNode($dm, $company, 'more-item', array('en' => 'More', 'de' => 'Mehr', 'fr' => 'Plus'), $dm->find(null, "$content_path/more"));
 
         $demo = $this->createMenuNode($dm, $main, 'demo-item', 'Demo', $dm->find(null, "$content_path/demo"));

--- a/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadRoutingData.php
+++ b/src/Sandbox/MainBundle/DataFixtures/PHPCR/LoadRoutingData.php
@@ -56,12 +56,8 @@ class LoadRoutingData extends ContainerAware implements FixtureInterface, Ordere
             $company->setContent($dm->find(null, "$content_path/company"));
             $dm->persist($company);
 
-            // special route that also supports adding the format as a parameter
             $team = new Route;
             $team->setPosition($company, 'team');
-            $team->setOption('add_format_pattern', true);
-            $team->setDefault('_format', 'html');
-            $team->setRequirement('_format', 'html|json|xml');
             $team->setContent($dm->find(null, "$content_path/team"));
             $dm->persist($team);
 

--- a/src/Sandbox/MainBundle/Resources/data/page.yml
+++ b/src/Sandbox/MainBundle/Resources/data/page.yml
@@ -65,14 +65,9 @@ static:
         body: |
             <h2>Our Team</h2>
             <p>There are some core developers and many other contributors. We need more help, so please contribute.</p>
-
-            <h2>REST example</h2>
-
-            <p>The route for this page also supports adding ".json" or ".xml" to the end in order to get a JSON or XML
-            rendered version. However actually the CMF also fully supports Accept header based content negotiation. So
-            using 'curl -H "Accept: application/json" http://cmf-sandbox.lo/app_dev.php/en/company/team' would work just
-            as well. In fact the sandbox is configured that it is possible to get an JSON/XML representation of all
-            content pages. For example 'curl -H "Accept: application/xml" http://cmf-sandbox.lo/app_dev.php/en'</p>
+            <h2>dicta facete eu vis</h2>
+            <p>Sonet affert an has. Nam id odio nisl eruditi. Te quo falli propriae delectus, ut animal meliore est, agam decore in sea. Prima debet fierent id sed. Usu debet paulo argumentum ex, solum homero in sed, modus laboramus et usu. Brute legendos contentiones ex pri.
+            Ut suscipit honestatis sed, per id facer euismod probatus. Ne persius posidonium eum, has elaboraret philosophia eu. No eam wisi choro labores. Sit id oratio aperiam electram, quodsi deterruisset no eum, vel modo quaeque ei</p>
         blocks:
             additionalInfoBlock:
                 class: Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ContainerBlock

--- a/src/Sandbox/MainBundle/Resources/public/css/style.css
+++ b/src/Sandbox/MainBundle/Resources/public/css/style.css
@@ -67,7 +67,7 @@ hr {
     display: none;
 }
 
-#breadcrumb .breadcrumb {
+#breadcrumb .breadcrumb, #raw_format .raw_format {
     border: none;
     background-color: #4b4b4b;
     background-image: none;
@@ -92,6 +92,39 @@ hr {
 
 #breadcrumb .breadcrumb li:last-child:after {
     content: none;
+}
+
+#raw_format p {
+    text-align: right;
+    padding: 7px;
+    color: white;
+}
+
+#raw_format a {
+    cursor: pointer;
+}
+
+#raw_data_overlay {
+    background-color: #ddd;
+    border: 1px black solid;
+    position: absolute;
+    top: 100px;
+    left: 100px;
+    width: 80%;
+    display: none;
+    padding: 16px;
+}
+
+#overlay_description {
+    margin-bottom: 16px;
+    padding: 8px;
+    background-color: #eee;
+}
+
+#overlay_content {
+    font-family: courier, monospace;
+    padding: 8px;
+    white-space: pre-wrap;
 }
 
 #navigation ul {

--- a/src/Sandbox/MainBundle/Resources/public/js/rawdata.js
+++ b/src/Sandbox/MainBundle/Resources/public/js/rawdata.js
@@ -1,0 +1,24 @@
+$(document).ready(function () {
+    $("#raw_xml").on("click", function () {
+        $.ajax({
+           "dataType": "xml",
+            "success": function(xml) {
+                $("#overlay_content").text((new XMLSerializer()).serializeToString(xml));
+                $("#raw_data_overlay").show();
+            }
+        });
+    });
+    $("#raw_json").on("click", function () {
+        $.ajax({
+            "dataType": "json",
+            "success": function(json) {
+                $("#overlay_content").text(JSON.stringify(json, undefined, 4));
+                $("#raw_data_overlay").show();
+            }
+        });
+    });
+});
+
+$(document).keyup(function(e) {
+    if (e.keyCode == 27) { $("#raw_data_overlay").hide(); }   // esc
+});

--- a/src/Sandbox/MainBundle/Resources/translations/messages.de.yml
+++ b/src/Sandbox/MainBundle/Resources/translations/messages.de.yml
@@ -2,3 +2,9 @@ cmf:
     action_block:
         title: Demo Aktions-Block
         body: Dieser Inhalt wurde durch eine Symfony2 Controller Action gerendert. Er kann nicht inline editiert werden.
+    raw_data: |
+      <p>Dieses Fenster zeigt, wie Inhalt mit einem Accept Header im xml bzw json Format abgefragt werden kann.
+       Damit dies geht, muss das Format erlabut sein in fos_rest.format_listener.rules und braucht es Konfiguration
+       für den jms serializer für das Dokument in config.yml.</p>
+       <p><em>Escape Taste drücken um das Fenster wieder zu schliessen</em>.</p>
+    raw_data_hint: Rohdaten dieser Seite anzeigen.

--- a/src/Sandbox/MainBundle/Resources/translations/messages.en.yml
+++ b/src/Sandbox/MainBundle/Resources/translations/messages.en.yml
@@ -2,3 +2,9 @@ cmf:
     action_block:
         title: Demo Action Block
         body: This block content is rendered by a custom Symfony2 action. It has no inline-editing.
+    raw_data: |
+      <p>This window shows the output when requesting content with an accept-header asking for xml / json.
+       This is enabled by configuring a rule in fos_rest.format_listener.rules and a jms serializer mapping
+       for the content document in config.yml.</p>
+       <p><em>Press the escape key to close</em>.</p>
+    raw_data_hint: Show raw data of this page.

--- a/src/Sandbox/MainBundle/Resources/translations/messages.fr.yml
+++ b/src/Sandbox/MainBundle/Resources/translations/messages.fr.yml
@@ -2,3 +2,9 @@ cmf:
     action_block:
         title: Demo block d'action
         body: Ce contenu est rendu par une action d'un controlleur Symfony2. Il n'a pas le inline editing.
+    raw_data: |
+      <p>Cette fenêtre montre le résultat obtenu quand on envoye un header Accept demandant du xml / json.
+       Pour controler les formats permit, on utilise les règles dans fos_rest.format_listener.rules et
+       on a besoin d'un mapping pour le document en question avec le jms serializer dans config.yml.</p>
+       <p><em>Tapper la touche escape pour férmer cette fenêtre</em>.</p>
+    raw_data_hint: Data brut de ce page.

--- a/src/Sandbox/MainBundle/Resources/views/skeleton.html.twig
+++ b/src/Sandbox/MainBundle/Resources/views/skeleton.html.twig
@@ -61,7 +61,7 @@
                 </div>
                 {% set currentItem = knp_menu_get('main').currentItem %}
                 {% if currentItem %}
-                <div id="breadcrumb" class="span12">
+                <div id="breadcrumb" class="span10">
                     <ul class="breadcrumb boxed">
                         {% for title, url in currentItem.breadcrumbsArray %}
                             <li><a href="{{url}}">{{ title }}</a></li>
@@ -69,6 +69,14 @@
                     </ul>
                 </div>
                 {% endif %}
+                {% block raw_data %}
+                <div id="raw_format" class="span2">
+                    <p class="raw_format boxed">Raw:
+                        <a id="raw_xml" title="{{ "cmf.raw_data_hint"|trans() }}">XML</a>,
+                        <a id="raw_json" title="{{ "cmf.raw_data_hint"|trans() }}">json</a>
+                    </p>
+                </div>
+                {% endblock raw_data %}
 
             </div>
 
@@ -116,8 +124,19 @@
             </div>
         </div>
 
+        <div id="raw_data_overlay" class="boxed">
+            <div id="overlay_description">{{ "cmf.raw_data"|trans()|raw }}</div>
+            <div id="overlay_content"></div>
+        </div>
+
         {% block bottom_scripts %}
             {% render(controller("cmf_create.jsloader.controller:includeJSFilesAction")) %}
+
+            {% javascripts
+                '@SandboxMainBundle/Resources/public/js/rawdata.js'
+            %}
+                <script src="{{ asset_url }}"></script>
+            {% endjavascripts %}
         {% endblock %}
     </body>
 </html>

--- a/src/Sandbox/TestBundle/Resources/views/Test/index.html.twig
+++ b/src/Sandbox/TestBundle/Resources/views/Test/index.html.twig
@@ -1,5 +1,7 @@
 {% extends "SandboxMainBundle::skeleton.html.twig" %}
 
+{% block raw_data %}{# can't get raw data for this #}{% endblock %}
+
 {% block content %}
 <div class="hero-unit">
     <h1>Hello World!</h1>


### PR DESCRIPTION
this amends #268 to be more elegant.

TODO:
- [x] remove fos rest configuration about urls and such again
- [x] remove additional menu entries
- [x] make overlay a bit nicer, add explanation to top and handle ESC key to close overlay
