### PR TITLE
Update MenuExtension.php

### DIFF
--- a/src/AppBundle/Twig/MenuExtension.php
+++ b/src/AppBundle/Twig/MenuExtension.php
@@ -45,8 +45,9 @@ class MenuExtension extends \Twig_Extension
         }
 
         foreach ($item->getChildren() as $child) {
-            if (null !== $this->doGetCurrent($child)) {
-                return $child;
+            $result = $this->doGetCurrent($child);
+            if (null !== $result) {
+                return $result;
             }
         }
     }


### PR DESCRIPTION
Returning the actual matched item rather then the child in the loop.

Otherwise the knp_menu_get_breadcrumbs_array will not return the actual current item but will stop at the parent.