### PR TITLE
Use Github API token on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,15 @@ matrix:
       env: TRANSPORT=doctrine_dbal COMPOSER_INSTALL=1
 
 env:
-  - TRANSPORT=jackrabbit
-  - TRANSPORT=doctrine_dbal
+  matrix:
+    - TRANSPORT=jackrabbit
+    - TRANSPORT=doctrine_dbal
+  global:
+    secure: DY8dajugriGNObYRThdvC2acCd8zFbvxhJwlX6+KgQn71y+wvFMyqE9oMNbivuMtoGS6bCRLJNW1lujWzEjXn8BlDebJqR71szSeATsB6K/+Xw6iUqJOM5VVx7aHh1/3kdKrWzG2XdTIu2w0XYfNQ8KyIrJWHGRGBJzriPRRchU=
 
 before_install:
   - composer self-update
+  - composer config --no-interaction --global github-oauth.github.com $GITHUB_TRAVIS_TOKEN
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
 
 install: if [ "$COMPOSER_INSTALL" != "1" ]; then composer update --no-scripts --prefer-dist; else composer install --no-scripts --prefer-dist; fi
@@ -43,4 +47,3 @@ script: phpunit -c app
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"
-  email: "symfony-cmf-devs@googlegroups.com"


### PR DESCRIPTION
Currently, most of the dependencies are still loaded using `git clone`, because we reached the GitHub API limit. If we configure a token, this limit will be much higher.

I've used travis token encryption method here. This means it doesn't work for pull requests from forks, however I don't think that's a big problem for the CMF:

 * Quite a few pull requests are coming from the main repository
 * Dependencies don't change that often, as each branch build will cache the dependencies, most of the deps loaded during PR builds will use the cached deps.

I've also removed the email notification, as I don't think it works anymore and we don't use the mailing list every often anymore.