### PR TITLE
Use a login form instead of HTTP basic

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
     <head>
         <meta name="viewport" content=" minimum-scale=1.0, maximum-scale=1.0, width=device-width, user-scalable=no">
@@ -44,6 +44,10 @@
                 <div class="navbar-right">
                     <ul class="nav  navbar-nav">
                         <li><a href="{{ path('sonata_admin_dashboard') }}">Admin Dashboard</a></li>
+
+                        {% if is_granted('ROLE_ADMIN') %}
+                            <li><a href="{{ path('logout') }}">Logout</a></li>
+                        {% endif %}
                     </ul>
 
                     {% block language_selector %}

--- a/app/Resources/views/security/login.html.twig
+++ b/app/Resources/views/security/login.html.twig
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+    <head>
+        <meta name="viewport" content=" minimum-scale=1.0, maximum-scale=1.0, width=device-width, user-scalable=no">
+        <meta charset="utf-8" />
+
+        <title>Admin area login</title>
+
+        <link rel="stylesheet" href="{{ asset("assets/vendor/bootstrap.min.css") }}">
+        <link rel="stylesheet" href="{{ asset("assets/css/style.css") }}">
+        <style>
+            body { background:#fafafa; }
+            .login-form { margin-bottom:20px; }
+            .login-form-box{
+                width:430px;
+                margin-top:200px;
+                padding:20px;
+                background:rgba(255, 255, 255, .8);
+                border:1px solid #cee3ab;
+                border-top:5px solid #a3ca5f;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="login-form-box center-block">
+            <div class="alert  alert-info  clearfix">
+                <p>This login form is using the Security component.</p>
+
+                <a class="docref" href="https://symfony.com/doc/current/security/form_login_setup"><i class="glyphicon glyphicon-chevron-right"></i>Read about this feature in the documentation.</a>
+            </div>
+
+            <h3>Admin area</h3>
+
+            {% if error %}
+                <div class="alert alert-danger">
+                    <span class="glyphicon glyphicon-exclamation-sign"></span>
+                    {{ error.messageKey|trans(error.messageData, 'security') }}
+                </div>
+            {% endif %}
+
+            <form action="{{ path('login') }}" method="post" class="form-horizontal clearfix login-form">
+                <div class="form-group">
+                    <label for="username" class="col-sm-4">Username:</label>
+                    <div class="col-sm-8">
+                        <input type="text" class="form-control" id="username" name="_username" value="{{ last_username }}" />
+                        <span class="help-block">The demo username is "anna_admin".</span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="password" class="col-sm-4">Password:</label>
+                    <div class="col-sm-8">
+                        <input type="password" class="form-control" id="password" name="_password" />
+                        <span class="help-block">The demo password is "kitten".</span>
+                    </div>
+                </div>
+
+                <div class="col-sm-offset-4 col-sm-8">
+                    <button type="submit" class="btn btn-primary">Login</button>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -9,6 +9,11 @@ framework:
     session:
         storage_id: session.storage.filesystem
 
+security:
+    firewalls:
+        main:
+            http_basic: ~
+
 web_profiler:
     toolbar: false
     intercept_redirects: false

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -22,7 +22,3 @@ parameters:
     mailer_host:       localhost
     mailer_user:       ~
     mailer_password:   ~
-
-    security_users:
-        user:  { password: user, roles: [ 'ROLE_USER' ] }
-        admin: { password: admin, roles: [ 'ROLE_ADMIN' ] }

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,4 +1,6 @@
 security:
+    # *NEVER* store passwords as plaintext in production, this is purely for
+    # demo purposes.
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext
 
@@ -9,7 +11,11 @@ security:
     providers:
         in_memory:
             memory:
-                users: %security_users%
+                # Only for demo purposes. Of course, use a more
+                # secure password on production.
+                users:
+                    anna_admin: { password: kitten, roles: ROLE_ADMIN }
+                    admin:      { password: admin, roles: ROLE_ADMIN }
 
     firewalls:
         dev:
@@ -17,11 +23,12 @@ security:
             security: false
 
         main:
-            pattern: ^/
             anonymous: ~
-            http_basic:
-                realm: 'Secured Demo Area (username: admin, password: admin)'
+            form_login:
+                login_path: login
+                check_path: login
+            logout: ~
 
     access_control:
         - { path: ^(/(de|fr|en))?/admin, roles: ROLE_ADMIN }
-        #- { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/src/AppBundle/Controller/SecurityController.php
+++ b/src/AppBundle/Controller/SecurityController.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AppBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class SecurityController extends Controller
+{
+    /**
+     * @Route("/login", name="login")
+     */
+    public function loginAction(Request $request)
+    {
+        $authenticationUtils = $this->get('security.authentication_utils');
+        $error = $authenticationUtils->getLastAuthenticationError();
+        $lastUsername = $authenticationUtils->getLastUsername();
+
+        return $this->render('security/login.html.twig', array(
+            'last_username' => $lastUsername,
+            'error' => $error,
+        ));
+    }
+
+    /**
+     * @Route("/logout", name="logout")
+     */
+    public function logoutAction()
+    {
+    }
+}


### PR DESCRIPTION
Using a login form instead of HTTP has a couple advantages:

 * We can inform the user about the demo username and password
 * It's a more real use case. I don't think HTTP basic is used much in real world applications
 * It's a lot nicer than HTTP basic, the sandbox is meant to show how great the CMF is.

![cmf-login-form](https://cloud.githubusercontent.com/assets/749025/17398370/c1b97c66-5a3c-11e6-95e9-74e00df23daf.png)


/fixes #338 