### PR TITLE
Move sqlite database to var/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@
 /web/bundles/
 
 /app/config/phpcr.yml
-/app/app.sqlite
 /jackrabbit/
 /jackrabbit-standalone-*.jar
 /vagrant/.vagrant

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -16,7 +16,7 @@ parameters:
     database_name:
     database_user:
     database_password:
-    database_path: '%kernel.root_dir%/app.sqlite'
+    database_path: '%kernel.root_dir%/../var/app.sqlite'
 
     mailer_transport:  smtp
     mailer_host:       localhost


### PR DESCRIPTION
Imo, databases belong to the var directory. Makes the gitignore file a bit cleaner as well.