### PR TITLE
enable ckeditor again for static content admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
   - bin/console doctrine:phpcr:workspace:create sandbox_test -e=test
   - bin/console doctrine:phpcr:repository:init -e=test
 
-script: phpunit
+script: vendor/bin/simple-phpunit
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -136,7 +136,7 @@ cmf_sonata_phpcr_admin_integration:
         seo: ~
         menu: ~
         core: ~
-        content:
+        content: ~
         block:
             basepath: /cms/content
             menu_basepath: /cms/content

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -136,11 +136,12 @@ cmf_sonata_phpcr_admin_integration:
         seo: ~
         menu: ~
         core: ~
-        content: ~
+        content:
         block:
             basepath: /cms/content
             menu_basepath: /cms/content
         routing: ~
+    ivory_ckeditor: ~
 
 sonata_block:
     default_contexts: [cms]
@@ -280,7 +281,7 @@ sonata_seo:
 
 ivory_ck_editor:
     configs:
-        cmf_content: { toolbar: standard }
+        cmf_sonata_phpcr_admin_integration: { toolbar: standard }
 
 sensio_framework_extra:
     router:  { annotations: true }

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -136,12 +136,13 @@ cmf_sonata_phpcr_admin_integration:
         seo: ~
         menu: ~
         core: ~
-        content: ~
+        content:
+           ivory_ckeditor:
+              config_name: cmf_sonata_phpcr_admin_integration
         block:
             basepath: /cms/content
             menu_basepath: /cms/content
         routing: ~
-    ivory_ckeditor: ~
 
 sonata_block:
     default_contexts: [cms]

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony-cmf/seo-bundle": "^2.0",
         "symfony-cmf/routing": "^2.0",
         "symfony-cmf/routing-auto-bundle": "^2.0",
-        "symfony-cmf/sonata-phpcr-admin-integration-bundle": "dev-fix_ckeditor",
+        "symfony-cmf/sonata-phpcr-admin-integration-bundle": "^1.0@dev",
 
         "jackalope/jackalope-doctrine-dbal": "1.2.*",
         "jackalope/jackalope-jackrabbit": "1.2.*",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "doctrine/phpcr-odm": "^1.4",
 
         "sonata-project/cache-bundle": "^2.1",
-        "sonata-project/translation-bundle": "^2.0",
+        "sonata-project/translation-bundle": "2.1.0",
         "sonata-project/doctrine-phpcr-admin-bundle": "^2.0@dev",
 
         "jms/serializer-bundle": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony-cmf/seo-bundle": "^2.0",
         "symfony-cmf/routing": "^2.0",
         "symfony-cmf/routing-auto-bundle": "^2.0",
-        "symfony-cmf/sonata-phpcr-admin-integration-bundle": "^1.0@dev",
+        "symfony-cmf/sonata-phpcr-admin-integration-bundle": "dev-fix_ckeditor",
 
         "jackalope/jackalope-doctrine-dbal": "1.2.*",
         "jackalope/jackalope-jackrabbit": "1.2.*",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
     "require-dev": {
         "sensio/generator-bundle": "^3.0",
         "liip/functional-test-bundle": "^1.3",
-        "symfony-cmf/testing": "^2.0"
+        "symfony-cmf/testing": "^2.0",
+        "symfony/phpunit-bridge": "^3.2"
     },
     "minimum-stability": "RC",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fac15bad515e29e76debb43f90a13c6",
+    "hash": "f65cf35ff8d7903a981933bc8d36bca4",
+    "content-hash": "487e793f40cf713021988e85a1242dbc",
     "packages": [
         {
             "name": "aferrandini/urlizer",
@@ -48,7 +49,7 @@
                 "url",
                 "urlizer"
             ],
-            "time": "2012-11-15T19:49:27+00:00"
+            "time": "2012-11-15 19:49:27"
         },
         {
             "name": "burgov/key-value-form-bundle",
@@ -87,7 +88,7 @@
                 "MIT"
             ],
             "description": "A form type for managing key-value pairs",
-            "time": "2016-05-31T12:27:50+00:00"
+            "time": "2016-05-31 12:27:50"
         },
         {
             "name": "cocur/slugify",
@@ -151,7 +152,7 @@
                 "slug",
                 "slugify"
             ],
-            "time": "2017-02-09T19:27:52+00:00"
+            "time": "2017-02-09 19:27:52"
         },
         {
             "name": "container-interop/container-interop",
@@ -182,7 +183,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14T19:40:03+00:00"
+            "time": "2017-02-14 19:40:03"
         },
         {
             "name": "dantleech/glob-finder",
@@ -226,7 +227,7 @@
             ],
             "description": "Library offering object location from hierarchrical persistent storage systems using globs",
             "homepage": "http://www.github.com/dantleech/glob",
-            "time": "2016-08-23T14:48:07+00:00"
+            "time": "2016-08-23 14:48:07"
         },
         {
             "name": "doctrine/annotations",
@@ -294,7 +295,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2016-12-30T15:59:45+00:00"
+            "time": "2016-12-30 15:59:45"
         },
         {
             "name": "doctrine/cache",
@@ -364,7 +365,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29T11:16:17+00:00"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/collections",
@@ -431,7 +432,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2017-01-03T10:49:41+00:00"
+            "time": "2017-01-03 10:49:41"
         },
         {
             "name": "doctrine/common",
@@ -504,7 +505,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2017-01-13T14:02:13+00:00"
+            "time": "2017-01-13 14:02:13"
         },
         {
             "name": "doctrine/data-fixtures",
@@ -563,7 +564,7 @@
             "keywords": [
                 "database"
             ],
-            "time": "2016-09-20T10:07:57+00:00"
+            "time": "2016-09-20 10:07:57"
         },
         {
             "name": "doctrine/dbal",
@@ -634,7 +635,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-02-08T12:53:47+00:00"
+            "time": "2017-02-08 12:53:47"
         },
         {
             "name": "doctrine/doctrine-bundle",
@@ -715,7 +716,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2017-01-16T12:01:26+00:00"
+            "time": "2017-01-16 12:01:26"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -803,7 +804,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-01-26T17:28:51+00:00"
+            "time": "2016-01-26 17:28:51"
         },
         {
             "name": "doctrine/inflector",
@@ -870,7 +871,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2015-11-06 14:35:42"
         },
         {
             "name": "doctrine/instantiator",
@@ -924,7 +925,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "doctrine/lexer",
@@ -978,7 +979,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "time": "2014-09-09 13:34:57"
         },
         {
             "name": "doctrine/phpcr-bundle",
@@ -1056,7 +1057,7 @@
                 "persistence",
                 "phpcr"
             ],
-            "time": "2016-12-19T16:49:17+00:00"
+            "time": "2016-12-19 16:49:17"
         },
         {
             "name": "doctrine/phpcr-odm",
@@ -1137,7 +1138,7 @@
                 "odm",
                 "phpcr"
             ],
-            "time": "2017-02-09T12:13:23+00:00"
+            "time": "2017-02-09 12:13:23"
         },
         {
             "name": "egeloen/ckeditor-bundle",
@@ -1195,7 +1196,7 @@
             "keywords": [
                 "CKEditor"
             ],
-            "time": "2016-10-28T16:59:01+00:00"
+            "time": "2016-10-28 16:59:01"
         },
         {
             "name": "egeloen/json-builder",
@@ -1248,7 +1249,7 @@
                 "builder",
                 "json"
             ],
-            "time": "2015-12-06T13:20:24+00:00"
+            "time": "2015-12-06 13:20:24"
         },
         {
             "name": "eko/feedbundle",
@@ -1307,7 +1308,7 @@
                 "feed",
                 "rss"
             ],
-            "time": "2016-04-20T19:56:02+00:00"
+            "time": "2016-04-20 19:56:02"
         },
         {
             "name": "friendsofsymfony/rest-bundle",
@@ -1393,7 +1394,7 @@
             "keywords": [
                 "rest"
             ],
-            "time": "2015-12-29T16:02:50+00:00"
+            "time": "2015-12-29 16:02:50"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -1444,7 +1445,7 @@
             "keywords": [
                 "parameters management"
             ],
-            "time": "2015-11-10T17:04:01+00:00"
+            "time": "2015-11-10 17:04:01"
         },
         {
             "name": "jackalope/jackalope",
@@ -1497,7 +1498,7 @@
             "keywords": [
                 "phpcr"
             ],
-            "time": "2015-12-01T13:48:15+00:00"
+            "time": "2015-12-01 13:48:15"
         },
         {
             "name": "jackalope/jackalope-doctrine-dbal",
@@ -1561,7 +1562,7 @@
                 "phpcr",
                 "transport implementation"
             ],
-            "time": "2016-06-09T06:33:29+00:00"
+            "time": "2016-06-09 06:33:29"
         },
         {
             "name": "jackalope/jackalope-jackrabbit",
@@ -1626,7 +1627,7 @@
                 "phpcr",
                 "transport implementation"
             ],
-            "time": "2015-10-18T16:25:35+00:00"
+            "time": "2015-10-18 16:25:35"
         },
         {
             "name": "jdorn/sql-formatter",
@@ -1676,7 +1677,7 @@
                 "highlight",
                 "sql"
             ],
-            "time": "2014-01-12T16:20:24+00:00"
+            "time": "2014-01-12 16:20:24"
         },
         {
             "name": "jms/metadata",
@@ -1728,7 +1729,7 @@
                 "xml",
                 "yaml"
             ],
-            "time": "2014-07-12T07:13:19+00:00"
+            "time": "2014-07-12 07:13:19"
         },
         {
             "name": "jms/parser-lib",
@@ -1763,7 +1764,7 @@
                 "Apache2"
             ],
             "description": "A library for easily creating recursive-descent parsers.",
-            "time": "2012-11-18T18:08:43+00:00"
+            "time": "2012-11-18 18:08:43"
         },
         {
             "name": "jms/serializer",
@@ -1839,7 +1840,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-02-14T14:35:22+00:00"
+            "time": "2017-02-14 14:35:22"
         },
         {
             "name": "jms/serializer-bundle",
@@ -1909,7 +1910,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2015-11-10T12:26:42+00:00"
+            "time": "2015-11-10 12:26:42"
         },
         {
             "name": "knplabs/knp-menu",
@@ -1975,7 +1976,7 @@
                 "menu",
                 "tree"
             ],
-            "time": "2016-09-22T07:36:19+00:00"
+            "time": "2016-09-22 07:36:19"
         },
         {
             "name": "knplabs/knp-menu-bundle",
@@ -2032,7 +2033,7 @@
             "keywords": [
                 "menu"
             ],
-            "time": "2016-09-22T12:24:40+00:00"
+            "time": "2016-09-22 12:24:40"
         },
         {
             "name": "kriswallsmith/assetic",
@@ -2109,7 +2110,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2016-11-11T18:43:20+00:00"
+            "time": "2016-11-11 18:43:20"
         },
         {
             "name": "lunetics/locale-bundle",
@@ -2177,7 +2178,7 @@
                 "multilanguage",
                 "router"
             ],
-            "time": "2016-06-29T06:36:59+00:00"
+            "time": "2016-06-29 06:36:59"
         },
         {
             "name": "monolog/monolog",
@@ -2255,7 +2256,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-11-26T00:15:39+00:00"
+            "time": "2016-11-26 00:15:39"
         },
         {
             "name": "paragonie/random_compat",
@@ -2303,7 +2304,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-11-07T23:38:38+00:00"
+            "time": "2016-11-07 23:38:38"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -2351,7 +2352,7 @@
                 "sequence",
                 "set"
             ],
-            "time": "2015-05-17T12:39:23+00:00"
+            "time": "2015-05-17 12:39:23"
         },
         {
             "name": "phpcr/phpcr",
@@ -2409,7 +2410,7 @@
                 "contentrepository",
                 "phpcr"
             ],
-            "time": "2017-02-08T13:54:11+00:00"
+            "time": "2017-02-08 13:54:11"
         },
         {
             "name": "phpcr/phpcr-utils",
@@ -2480,7 +2481,7 @@
                 "contentrepository",
                 "phpcr"
             ],
-            "time": "2016-12-06T00:12:18+00:00"
+            "time": "2016-12-06 00:12:18"
         },
         {
             "name": "phpoption/phpoption",
@@ -2530,7 +2531,7 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25T16:39:46+00:00"
+            "time": "2015-07-25 16:39:46"
         },
         {
             "name": "psr/cache",
@@ -2576,7 +2577,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2016-08-06 20:24:11"
         },
         {
             "name": "psr/container",
@@ -2625,7 +2626,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2017-02-14 16:28:37"
         },
         {
             "name": "psr/log",
@@ -2672,7 +2673,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "sensio/distribution-bundle",
@@ -2724,7 +2725,7 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2017-01-10T14:58:45+00:00"
+            "time": "2017-01-10 14:58:45"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -2794,7 +2795,7 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2017-02-15T06:52:30+00:00"
+            "time": "2017-02-15 06:52:30"
         },
         {
             "name": "sensiolabs/security-checker",
@@ -2838,7 +2839,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2017-02-18T17:53:25+00:00"
+            "time": "2017-02-18 17:53:25"
         },
         {
             "name": "sonata-project/admin-bundle",
@@ -2935,7 +2936,7 @@
                 "bootstrap",
                 "sonata"
             ],
-            "time": "2017-02-03T09:12:44+00:00"
+            "time": "2017-02-03 09:12:44"
         },
         {
             "name": "sonata-project/block-bundle",
@@ -3007,7 +3008,7 @@
                 "block",
                 "sonata"
             ],
-            "time": "2017-01-17T11:56:59+00:00"
+            "time": "2017-01-17 11:56:59"
         },
         {
             "name": "sonata-project/cache",
@@ -3070,7 +3071,7 @@
                 "mongodb",
                 "redis"
             ],
-            "time": "2015-09-18T14:40:58+00:00"
+            "time": "2015-09-18 14:40:58"
         },
         {
             "name": "sonata-project/cache-bundle",
@@ -3146,7 +3147,7 @@
             "keywords": [
                 "cache block"
             ],
-            "time": "2016-09-06T13:06:43+00:00"
+            "time": "2016-09-06 13:06:43"
         },
         {
             "name": "sonata-project/core-bundle",
@@ -3223,7 +3224,7 @@
             "keywords": [
                 "sonata"
             ],
-            "time": "2017-01-20T09:25:37+00:00"
+            "time": "2017-01-20 09:25:37"
         },
         {
             "name": "sonata-project/doctrine-phpcr-admin-bundle",
@@ -3369,7 +3370,7 @@
                 "export",
                 "xls"
             ],
-            "time": "2017-02-09T16:39:40+00:00"
+            "time": "2017-02-09 16:39:40"
         },
         {
             "name": "sonata-project/seo-bundle",
@@ -3440,7 +3441,7 @@
                 "seo",
                 "sonata"
             ],
-            "time": "2017-02-02T10:19:33+00:00"
+            "time": "2017-02-02 10:19:33"
         },
         {
             "name": "sonata-project/translation-bundle",
@@ -3515,7 +3516,7 @@
                 "i18n",
                 "translation"
             ],
-            "time": "2017-01-17T11:36:37+00:00"
+            "time": "2017-01-17 11:36:37"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -3569,7 +3570,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2017-02-13T07:52:53+00:00"
+            "time": "2017-02-13 07:52:53"
         },
         {
             "name": "symfony-cmf/block-bundle",
@@ -3633,7 +3634,7 @@
                 "block",
                 "content fragments"
             ],
-            "time": "2017-02-10T15:14:53+00:00"
+            "time": "2017-02-10 15:14:53"
         },
         {
             "name": "symfony-cmf/content-bundle",
@@ -3693,7 +3694,7 @@
             "keywords": [
                 "Symfony CMF"
             ],
-            "time": "2017-02-18T10:13:53+00:00"
+            "time": "2017-02-18 10:13:53"
         },
         {
             "name": "symfony-cmf/core-bundle",
@@ -3757,7 +3758,7 @@
             "keywords": [
                 "Symfony CMF"
             ],
-            "time": "2017-02-10T12:02:41+00:00"
+            "time": "2017-02-10 12:02:41"
         },
         {
             "name": "symfony-cmf/menu-bundle",
@@ -3818,7 +3819,7 @@
                 "Symfony CMF",
                 "menu"
             ],
-            "time": "2017-02-21T11:53:51+00:00"
+            "time": "2017-02-21 11:53:51"
         },
         {
             "name": "symfony-cmf/resource",
@@ -3875,7 +3876,7 @@
             ],
             "description": "Bundle which facilitates document resource location via Puli",
             "homepage": "http://cmf.symfony.com",
-            "time": "2017-01-27T13:41:51+00:00"
+            "time": "2017-01-27 13:41:51"
         },
         {
             "name": "symfony-cmf/resource-bundle",
@@ -3929,7 +3930,7 @@
             ],
             "description": "Bundle which facilitates document resource location",
             "homepage": "http://cmf.symfony.com",
-            "time": "2017-01-27T15:48:45+00:00"
+            "time": "2017-01-27 15:48:45"
         },
         {
             "name": "symfony-cmf/resource-rest-bundle",
@@ -3988,7 +3989,7 @@
             ],
             "description": "Bundle which provides a REST API for resources",
             "homepage": "http://cmf.symfony.com",
-            "time": "2017-01-27T16:00:58+00:00"
+            "time": "2017-01-27 16:00:58"
         },
         {
             "name": "symfony-cmf/routing",
@@ -4048,7 +4049,7 @@
                 "database",
                 "routing"
             ],
-            "time": "2017-02-10T14:56:26+00:00"
+            "time": "2017-02-10 14:56:26"
         },
         {
             "name": "symfony-cmf/routing-auto",
@@ -4105,7 +4106,7 @@
             ],
             "description": "Component for automatically creating and managing routes for persisted objects",
             "homepage": "http://cmf.symfony.com",
-            "time": "2017-01-05T20:50:43+00:00"
+            "time": "2017-01-05 20:50:43"
         },
         {
             "name": "symfony-cmf/routing-auto-bundle",
@@ -4164,7 +4165,7 @@
             ],
             "description": "Bundle which automatically creates and manages routes for persisted objects",
             "homepage": "http://cmf.symfony.com",
-            "time": "2017-01-21T13:37:46+00:00"
+            "time": "2017-01-21 13:37:46"
         },
         {
             "name": "symfony-cmf/routing-bundle",
@@ -4229,7 +4230,7 @@
                 "database",
                 "routing"
             ],
-            "time": "2017-02-21T13:41:34+00:00"
+            "time": "2017-02-21 13:41:34"
         },
         {
             "name": "symfony-cmf/seo-bundle",
@@ -4302,7 +4303,7 @@
                 "Symfony CMF",
                 "seo"
             ],
-            "time": "2017-02-10T14:50:21+00:00"
+            "time": "2017-02-10 14:50:21"
         },
         {
             "name": "symfony-cmf/slugifier-api",
@@ -4348,7 +4349,7 @@
                 "slugify",
                 "urlize"
             ],
-            "time": "2017-02-18T23:11:17+00:00"
+            "time": "2017-02-18 23:11:17"
         },
         {
             "name": "symfony-cmf/sonata-phpcr-admin-integration-bundle",
@@ -4356,12 +4357,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony-cmf/sonata-phpcr-admin-integration-bundle.git",
-                "reference": "424a06362f608645994f8c5f01522dfe7898dd5f"
+                "reference": "6785354ab8526031788ffff0a684508cb318bd28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/sonata-phpcr-admin-integration-bundle/zipball/424a06362f608645994f8c5f01522dfe7898dd5f",
-                "reference": "424a06362f608645994f8c5f01522dfe7898dd5f",
+                "url": "https://api.github.com/repos/symfony-cmf/sonata-phpcr-admin-integration-bundle/zipball/6785354ab8526031788ffff0a684508cb318bd28",
+                "reference": "6785354ab8526031788ffff0a684508cb318bd28",
                 "shasum": ""
             },
             "require": {
@@ -4376,11 +4377,12 @@
                 "doctrine/doctrine-bundle": "^1.3",
                 "doctrine/orm": "^2.4",
                 "doctrine/phpcr-odm": "^2.0",
+                "egeloen/ckeditor-bundle": "^4.0",
                 "matthiasnoback/symfony-config-test": "^1.3.1",
                 "matthiasnoback/symfony-dependency-injection-test": "~0.6",
                 "symfony-cmf/block-bundle": "^2.0",
                 "symfony-cmf/content-bundle": "^2.0",
-                "symfony-cmf/core-bundle": "^2.0.0-RC2",
+                "symfony-cmf/core-bundle": "^2.0",
                 "symfony-cmf/menu-bundle": "^2.0",
                 "symfony-cmf/routing-bundle": "^2.0",
                 "symfony-cmf/seo-bundle": "^2.0",
@@ -4391,6 +4393,7 @@
                 "doctrine/doctrine-bundle": "To persist the metadata in ORM entities",
                 "doctrine/orm": "To persist the metadata in ORM entities, ~2.4",
                 "doctrine/phpcr-bundle": "To persist the metadata in PHPCR ODM documents",
+                "egeloen/ckeditor-bundle": "To have CkEditor support on textareas.",
                 "symfony-cmf/routing-bundle": "To make use of the alternate locale provider."
             },
             "type": "symfony-bundle",
@@ -4422,7 +4425,7 @@
                 "admin",
                 "sonata"
             ],
-            "time": "2017-02-15 13:12:07"
+            "time": "2017-03-19 09:03:48"
         },
         {
             "name": "symfony-cmf/symfony-cmf",
@@ -4478,7 +4481,7 @@
             ],
             "description": "Symfony Content Management Framework",
             "homepage": "http://cmf.symfony.com",
-            "time": "2017-02-01T16:01:06+00:00"
+            "time": "2017-02-01 16:01:06"
         },
         {
             "name": "symfony-cmf/tree-browser-bundle",
@@ -4529,7 +4532,7 @@
                 "phpcr",
                 "tree"
             ],
-            "time": "2017-02-09T12:54:18+00:00"
+            "time": "2017-02-09 12:54:18"
         },
         {
             "name": "symfony/assetic-bundle",
@@ -4599,7 +4602,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2016-11-22T11:42:57+00:00"
+            "time": "2016-11-22 11:42:57"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -4659,7 +4662,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2017-01-10T20:01:51+00:00"
+            "time": "2017-01-10 20:01:51"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -4712,7 +4715,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -4770,7 +4773,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -4829,7 +4832,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -4885,7 +4888,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -4944,7 +4947,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-util",
@@ -4996,7 +4999,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/security-acl",
@@ -5057,7 +5060,7 @@
             ],
             "description": "Symfony Security Component - ACL (Access Control List)",
             "homepage": "https://symfony.com",
-            "time": "2015-12-28T09:39:46+00:00"
+            "time": "2015-12-28 09:39:46"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -5116,7 +5119,7 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "time": "2016-12-20T04:44:33+00:00"
+            "time": "2016-12-20 04:44:33"
         },
         {
             "name": "symfony/symfony",
@@ -5259,7 +5262,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-02-17T00:00:43+00:00"
+            "time": "2017-02-17 00:00:43"
         },
         {
             "name": "twig/extensions",
@@ -5311,7 +5314,7 @@
                 "i18n",
                 "text"
             ],
-            "time": "2016-10-25T17:34:14+00:00"
+            "time": "2016-10-25 17:34:14"
         },
         {
             "name": "twig/twig",
@@ -5372,7 +5375,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-01-11T19:36:15+00:00"
+            "time": "2017-01-11 19:36:15"
         },
         {
             "name": "webmozart/assert",
@@ -5422,7 +5425,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2016-11-23 20:04:58"
         },
         {
             "name": "webmozart/path-util",
@@ -5468,7 +5471,7 @@
                 }
             ],
             "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
-            "time": "2015-12-17T08:42:14+00:00"
+            "time": "2015-12-17 08:42:14"
         },
         {
             "name": "willdurand/jsonp-callback-validator",
@@ -5508,7 +5511,7 @@
                 }
             ],
             "description": "JSONP callback validator.",
-            "time": "2014-01-20T22:35:06+00:00"
+            "time": "2014-01-20 22:35:06"
         },
         {
             "name": "willdurand/negotiation",
@@ -5557,7 +5560,7 @@
                 "header",
                 "negotiation"
             ],
-            "time": "2015-10-01T07:42:40+00:00"
+            "time": "2015-10-01 07:42:40"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -5601,7 +5604,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2016-06-30T19:48:38+00:00"
+            "time": "2016-06-30 19:48:38"
         },
         {
             "name": "zendframework/zend-feed",
@@ -5662,7 +5665,7 @@
                 "feed",
                 "zf2"
             ],
-            "time": "2016-02-11T18:54:29+00:00"
+            "time": "2016-02-11 18:54:29"
         },
         {
             "name": "zendframework/zend-http",
@@ -5712,7 +5715,7 @@
                 "http",
                 "zf2"
             ],
-            "time": "2017-01-31T14:41:02+00:00"
+            "time": "2017-01-31 14:41:02"
         },
         {
             "name": "zendframework/zend-loader",
@@ -5756,7 +5759,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03T14:05:47+00:00"
+            "time": "2015-06-03 14:05:47"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -5817,7 +5820,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2017-02-15T15:29:48+00:00"
+            "time": "2017-02-15 15:29:48"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -5862,7 +5865,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-09-13T14:38:50+00:00"
+            "time": "2016-09-13 14:38:50"
         },
         {
             "name": "zendframework/zend-uri",
@@ -5909,7 +5912,7 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17T22:38:51+00:00"
+            "time": "2016-02-17 22:38:51"
         },
         {
             "name": "zendframework/zend-validator",
@@ -5980,7 +5983,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2017-01-29T17:24:24+00:00"
+            "time": "2017-01-29 17:24:24"
         }
     ],
     "packages-dev": [
@@ -6040,7 +6043,7 @@
                 "javascript",
                 "routing"
             ],
-            "time": "2015-10-28T15:08:39+00:00"
+            "time": "2015-10-28 15:08:39"
         },
         {
             "name": "liip/functional-test-bundle",
@@ -6118,7 +6121,7 @@
             "keywords": [
                 "Symfony2"
             ],
-            "time": "2017-01-11T18:04:59+00:00"
+            "time": "2017-01-11 18:04:59"
         },
         {
             "name": "sensio/generator-bundle",
@@ -6170,7 +6173,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2016-12-05T16:01:19+00:00"
+            "time": "2016-12-05 16:01:19"
         },
         {
             "name": "symfony-cmf/testing",
@@ -6222,7 +6225,7 @@
                 }
             ],
             "description": "Component providing tools for writing tests with Symfony.",
-            "time": "2017-02-18T17:34:40+00:00"
+            "time": "2017-02-18 17:34:40"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -6281,7 +6284,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21T17:06:35+00:00"
+            "time": "2017-01-21 17:06:35"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f65cf35ff8d7903a981933bc8d36bca4",
-    "content-hash": "487e793f40cf713021988e85a1242dbc",
+    "hash": "a25ba9b7204cb01fd3cef6c01024c9a4",
+    "content-hash": "3750096c8549bf5bb36a7dacc3900af9",
     "packages": [
         {
             "name": "aferrandini/urlizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a25ba9b7204cb01fd3cef6c01024c9a4",
-    "content-hash": "3750096c8549bf5bb36a7dacc3900af9",
+    "hash": "227e0398f75554f347284178d9ca6e58",
+    "content-hash": "8587906d094e967fe809696c01ed1852",
     "packages": [
         {
             "name": "aferrandini/urlizer",
@@ -4357,12 +4357,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony-cmf/sonata-phpcr-admin-integration-bundle.git",
-                "reference": "6785354ab8526031788ffff0a684508cb318bd28"
+                "reference": "75ecf66846b624b1cc803d01c8e2c8fb2d9a132c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/sonata-phpcr-admin-integration-bundle/zipball/6785354ab8526031788ffff0a684508cb318bd28",
-                "reference": "6785354ab8526031788ffff0a684508cb318bd28",
+                "url": "https://api.github.com/repos/symfony-cmf/sonata-phpcr-admin-integration-bundle/zipball/75ecf66846b624b1cc803d01c8e2c8fb2d9a132c",
+                "reference": "75ecf66846b624b1cc803d01c8e2c8fb2d9a132c",
                 "shasum": ""
             },
             "require": {
@@ -4425,7 +4425,7 @@
                 "admin",
                 "sonata"
             ],
-            "time": "2017-03-19 09:03:48"
+            "time": "2017-04-27 20:12:55"
         },
         {
             "name": "symfony-cmf/symfony-cmf",
@@ -6229,20 +6229,23 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.2.4",
+            "version": "v3.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "996374975357b569ea319ec1c98c5ca0f7dda610"
+                "reference": "00916603c524b8048906de460b7ea0dfa1651281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/996374975357b569ea319ec1c98c5ca0f7dda610",
-                "reference": "996374975357b569ea319ec1c98c5ca0f7dda610",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/00916603c524b8048906de460b7ea0dfa1651281",
+                "reference": "00916603c524b8048906de460b7ea0dfa1651281",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": ">=6.0"
             },
             "suggest": {
                 "ext-zip": "Zip support is required when using bin/simple-phpunit",
@@ -6284,7 +6287,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 17:06:35"
+            "time": "2017-04-12 14:13:17"
         }
     ],
     "aliases": [],

--- a/web/config.php
+++ b/web/config.php
@@ -14,10 +14,10 @@ if (!isset($_SERVER['HTTP_HOST'])) {
     exit('This script cannot be run from the CLI. Run it from a browser.');
 }
 
-if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
+if (!in_array(@$_SERVER['REMOTE_ADDR'], [
     '127.0.0.1',
     '::1',
-))) {
+])) {
     header('HTTP/1.0 403 Forbidden');
     exit('This script is only accessible from localhost.');
 }

--- a/web/config.php
+++ b/web/config.php
@@ -14,10 +14,10 @@ if (!isset($_SERVER['HTTP_HOST'])) {
     exit('This script cannot be run from the CLI. Run it from a browser.');
 }
 
-if (!in_array(@$_SERVER['REMOTE_ADDR'], [
+if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
     '127.0.0.1',
     '::1',
-])) {
+))) {
     header('HTTP/1.0 403 Forbidden');
     exit('This script is only accessible from localhost.');
 }


### PR DESCRIPTION
fix https://github.com/symfony-cmf/sonata-phpcr-admin-integration-bundle/issues/89

Merge when https://github.com/symfony-cmf/sonata-phpcr-admin-integration-bundle/pull/100 is merged. This will enable the ck editor on static content admin again.